### PR TITLE
Add editable mode UI for custom quantities

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,9 +1,11 @@
-import React, { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import axios from "axios";
 import GraphView from "./GraphView";
 import DocPanel from "./components/DocPanel";
 import OverviewGrid from "./components/OverviewGrid";
 import UnderTheHoodPanel from './components/UnderTheHoodPanel';
+import AddQuantityForm from "./components/AddQuantityForm";
+import { useSelection } from "./store/selection";
 
 type ApiGraph = {
   package: string;
@@ -38,6 +40,13 @@ export default function App() {
   const [headBranch, setHeadBranch] = useState<string>("");
   const [diffData, setDiffData] = useState<any | null>(null);
   const [diffLoading, setDiffLoading] = useState<boolean>(false);
+
+  // editable mode
+  const [editableMode, setEditableMode] = useState<boolean>(false);
+  const [addLoading, setAddLoading] = useState<boolean>(false);
+  const [addErr, setAddErr] = useState<string | null>(null);
+
+  const { selected, setSelected } = useSelection();
 
   // overview mode
   const [mode, setMode] = useState<"graph" | "overview">("graph");
@@ -150,12 +159,82 @@ export default function App() {
     }
   };
 
+  const refreshSelectionQuantities = (nextGraph: ApiGraph) => {
+    if (!selected || selected.kind !== "class") return;
+    const quantities = (nextGraph.nodes || [])
+      .filter((n: any) => n.kind === "quantity" && n.owner === selected.id)
+      .map((n: any) => ({
+        id: n.id,
+        name: n.label,
+        dtype: n.dtype ?? undefined,
+        shape: n.shape ?? undefined,
+        card: n.card ?? undefined,
+        doc: n.doc ?? undefined,
+        path: n.path ?? undefined,
+        line: typeof n.line === "number" ? n.line : undefined,
+        owner: n.owner ?? selected.id
+      }));
+
+    setSelected({ ...selected, quantities });
+  };
+
+  const addCustomQuantity = async ({ quantityName, dtype, docstring }: { quantityName: string; dtype: string; docstring: string }) => {
+    if (!graph) {
+      setAddErr("Build a graph first to add a quantity.");
+      return;
+    }
+    if (!selected || selected.kind !== "class") {
+      setAddErr("Select a class node to attach the quantity.");
+      return;
+    }
+
+    setAddLoading(true);
+    setAddErr(null);
+    try {
+      const r = await api.post(
+        "/schema/custom-quantity",
+        {
+          package: pkg,
+          class_name: selected.name,
+          quantity_name: quantityName,
+          dtype,
+          docstring: docstring || null,
+        },
+        {
+          params: {
+            root,
+            include_subsections: includeSubsections,
+            allow_cross_module: crossModules,
+            base_namespace: namespace || undefined,
+          },
+        }
+      );
+      const updated = r.data as ApiGraph;
+      setGraph(updated);
+      refreshSelectionQuantities(updated);
+    } catch (e: any) {
+      setAddErr(e?.response?.data?.detail || String(e));
+    } finally {
+      setAddLoading(false);
+    }
+  };
+
   useEffect(() => {
     loadRoots();
     loadBranches();
     loadPackages();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  const selectedClassName = selected?.kind === "class" ? selected.name : null;
+  const addBlockedReason =
+    mode !== "graph"
+      ? "Switch to diagram view to add quantities"
+      : diffData
+        ? "Exit branch comparison to add quantities"
+        : !graph
+          ? "Build a graph first to add quantities"
+          : null;
 
   return (
     <main>
@@ -326,6 +405,30 @@ export default function App() {
         {err ? (
           <p style={{ color: "#b91c1c", marginTop: 10, whiteSpace: "pre-wrap" }}>{err}</p>
         ) : null}
+
+        <hr />
+        <div className="row" style={{ marginTop: 6 }}>
+          <label>
+            <input
+              type="checkbox"
+              checked={editableMode}
+              onChange={(e) => {
+                setEditableMode(e.target.checked);
+                setAddErr(null);
+              }}
+            />{" "}
+            Editable mode
+          </label>
+        </div>
+
+        <AddQuantityForm
+          enabled={editableMode && !addBlockedReason}
+          blockedReason={addBlockedReason}
+          targetClass={selectedClassName}
+          onSubmit={addCustomQuantity}
+          submitting={addLoading}
+          error={addErr}
+        />
 
         {/* Branch comparison */}
         <hr />

--- a/web/src/BranchDiffBar.tsx
+++ b/web/src/BranchDiffBar.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from "react";
-import { listBranches, getDiff, DiffResponse } from "./api";
+import { useEffect, useState } from "react";
+import { listBranches, getDiff, type DiffResponse } from "./api";
 
 export default function BranchDiffBar({ onDiff }: { onDiff: (d: DiffResponse) => void }) {
   const [branches, setBranches] = useState<string[]>([]);

--- a/web/src/GraphView.tsx
+++ b/web/src/GraphView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import cytoscape from "cytoscape";
 import elk from "elkjs/lib/elk.bundled.js";
 import cytoscapeElk from "cytoscape-elk";

--- a/web/src/GraphView.tsx
+++ b/web/src/GraphView.tsx
@@ -190,7 +190,7 @@ export default function GraphView({ nodes, edges, diff }: Props) {
             color: "#0f172a",
             label: "data(label)",
             "text-wrap": "wrap",
-            "text-max-width": 280,
+            "text-max-width": "280px",
             "font-size": 12,
             "font-family": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace",
             padding: "8px",
@@ -202,7 +202,7 @@ export default function GraphView({ nodes, edges, diff }: Props) {
             "shadow-color": "#94a3b8",
             "shadow-offset-x": 2,
             "shadow-offset-y": 4
-          }
+          } as any
         },
         {
           selector: "edge[type='composition']",
@@ -221,7 +221,7 @@ export default function GraphView({ nodes, edges, diff }: Props) {
             "text-margin-y": -6,
             "text-background-color": "#f5f7fa",
             "text-background-opacity": 1,
-            "text-background-padding": 2
+            "text-background-padding": "2px"
           }
         },
         { selector: ".hidden", style: { display: "none" } },

--- a/web/src/components/AddQuantityForm.tsx
+++ b/web/src/components/AddQuantityForm.tsx
@@ -1,0 +1,108 @@
+import React, { useMemo, useState } from "react";
+
+type FormData = {
+  quantityName: string;
+  dtype: string;
+  docstring: string;
+};
+
+type Props = {
+  enabled: boolean;
+  targetClass: string | null;
+  onSubmit: (data: FormData) => Promise<void>;
+  submitting: boolean;
+  error: string | null;
+  blockedReason?: string | null;
+};
+
+const SUPPORTED_DTYPES = ["bool", "datetime", "float", "int", "str"];
+
+export default function AddQuantityForm({ enabled, targetClass, onSubmit, submitting, error, blockedReason }: Props) {
+  const [quantityName, setQuantityName] = useState("");
+  const [dtype, setDtype] = useState(SUPPORTED_DTYPES[0]);
+  const [docstring, setDocstring] = useState("");
+
+  const disabledReason = useMemo(() => {
+    if (blockedReason) return blockedReason;
+    if (!enabled) return "Enable editable mode to add quantities";
+    if (!targetClass) return "Select a class node to target";
+    return null;
+  }, [enabled, targetClass, blockedReason]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (disabledReason) return;
+    await onSubmit({ quantityName: quantityName.trim(), dtype, docstring: docstring.trim() });
+  };
+
+  const canSubmit = quantityName.trim().length > 0 && !submitting && !disabledReason;
+
+  return (
+    <form onSubmit={handleSubmit} className="panel" style={{ marginTop: 8, display: "flex", flexDirection: "column", gap: 8 }}>
+      <div>
+        <div className="label" style={{ marginBottom: 2 }}>Target class</div>
+        <div style={{ fontWeight: 600 }}>{targetClass ?? "—"}</div>
+      </div>
+
+      <div>
+        <label className="label" htmlFor="quantityName">Quantity name</label>
+        <input
+          id="quantityName"
+          className="input"
+          value={quantityName}
+          onChange={(e) => setQuantityName(e.target.value)}
+          placeholder="e.g. new_quantity"
+          disabled={!!disabledReason}
+          required
+        />
+      </div>
+
+      <div>
+        <label className="label" htmlFor="dtype">Type</label>
+        <select
+          id="dtype"
+          className="select"
+          value={dtype}
+          onChange={(e) => setDtype(e.target.value)}
+          disabled={!!disabledReason}
+        >
+          {SUPPORTED_DTYPES.map((t) => (
+            <option key={t} value={t}>{t}</option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label className="label" htmlFor="docstring">Docstring (optional)</label>
+        <textarea
+          id="docstring"
+          className="input"
+          style={{ minHeight: 60, resize: "vertical" }}
+          value={docstring}
+          onChange={(e) => setDocstring(e.target.value)}
+          placeholder="Describe the quantity"
+          disabled={!!disabledReason}
+        />
+      </div>
+
+      {error && (
+        <div style={{ color: "#b91c1c", fontSize: 13 }}>
+          {error}
+        </div>
+      )}
+
+      {disabledReason && (
+        <div style={{ color: "#6b7280", fontSize: 13 }}>
+          {disabledReason}
+        </div>
+      )}
+
+      <div className="row" style={{ justifyContent: "flex-end" }}>
+        <button className="btn" type="submit" disabled={!canSubmit}>
+          {submitting ? "Adding…" : "Add quantity"}
+        </button>
+      </div>
+    </form>
+  );
+}
+

--- a/web/src/components/DocPanel.tsx
+++ b/web/src/components/DocPanel.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useSelection, type QtyMeta } from "../store/selection";
 
 function QtyRow({ q, onClick }: { q: QtyMeta; onClick: () => void }) {

--- a/web/src/components/Graph.tsx
+++ b/web/src/components/Graph.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
-import cytoscape, { Core, ElementDefinition } from 'cytoscape';
+import { useEffect, useRef } from 'react';
+import cytoscape from 'cytoscape';
+import type { Core, ElementDefinition, LayoutOptions } from 'cytoscape';
 import elk from 'cytoscape-elk';
 import { useSelection } from '../store/selection';
-import { GraphPayload, GraphNodeData, GraphEdgeData } from '../types';
+import type { GraphPayload, GraphNodeData, GraphEdgeData } from '../types';
 
 cytoscape.use(elk);
 
@@ -43,11 +44,11 @@ function toCyElements(payload: GraphPayload): ElementDefinition[] {
 }
 
 export default function Graph() {
-  const containerRef = React.useRef<HTMLDivElement | null>(null);
-  const cyRef = React.useRef<Core | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const cyRef = useRef<Core | null>(null);
   const setSelected = useSelection(s => s.setSelected);
 
-  React.useEffect(() => {
+  useEffect(() => {
     let alive = true;
 
     const init = async () => {
@@ -61,7 +62,7 @@ export default function Graph() {
         layout: {
           name: 'elk',
           elk: { algorithm: 'layered', 'elk.direction': 'RIGHT' },
-        },
+        } as LayoutOptions,
         style: [
           {
             selector: 'node',
@@ -71,9 +72,9 @@ export default function Graph() {
               'border-color': '#94a3b8',
               label: 'data(name)',
               'text-wrap': 'wrap',
-              'text-max-width': 160,
+              'text-max-width': '160px',
               'font-size': 12,
-              padding: 8,
+              padding: '8px',
             },
           },
           {

--- a/web/src/store/selection.ts
+++ b/web/src/store/selection.ts
@@ -20,6 +20,11 @@ export type Selected = null | {
   path?: string;
   line?: number;
   quantities?: QtyMeta[];
+  dtype?: string;
+  shape?: string | null;
+  card?: string | null;
+  owner?: string;
+  fqid?: string;
 };
 
 type SelectionState = {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -1,16 +1,19 @@
-// web/src/store/selection.ts
-import { create } from 'zustand';
-
-type Selected = null | {
+export type GraphNodeData = {
   id: string;
-  kind: 'class' | 'quantity';
   name: string;
-  doc: string;
-  path?: string;
-  line?: number;
+  kind: 'class' | 'quantity';
+  doc?: string | null;
+  path?: string | null;
+  line?: number | null;
 };
 
-export const useSelection = create<{
-  selected: Selected;
-  setSelected: (s: Selected) => void;
-}>(set => ({ selected: null, setSelected: s => set(s) }));
+export type GraphEdgeData = {
+  id?: string;
+  source: string;
+  target: string;
+};
+
+export type GraphPayload = {
+  nodes: GraphNodeData[];
+  edges: GraphEdgeData[];
+};

--- a/web/src/types/cytoscape-elk.d.ts
+++ b/web/src/types/cytoscape-elk.d.ts
@@ -1,0 +1,1 @@
+declare module 'cytoscape-elk';


### PR DESCRIPTION
## Summary
- add an editable-mode toggle and form so users can submit custom quantities to the selected class
- call the new /schema/custom-quantity endpoint and refresh the graph selection with the returned data


