### PR TITLE
Generalize schema repo configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Schema UML Viewer
 
-Interactive UML-style viewer for `nomad-simulations`. 
+Interactive UML-style viewer for NOMAD-compatible schemas (defaults to `nomad-simulations`).
 
 
 Back end: **FastAPI** · Front end: **React + Cytoscape + ELK**.
@@ -39,17 +39,20 @@ conda activate schema-uml
 pip install -r requirements.txt
 ```
 
-### 3) Point to your `nomad-simulations` repo
+### 3) Point to your schema repo
 The backend reads from a local clone. Set one of:
 ```bash
-# preferred
-export NOMAD_SIM_REPO=<somethingsomething>/nomad-simulations
-# alternative var also accepted by backend
+# preferred (general)
+export SCHEMA_UML_REPO=<path-or-URL-to-your-schema-repo>
+# backwards-compatible options also accepted by backend
+# export NOMAD_SIM_REPO=/path/to/nomad-simulations
 # export GIT_REPO_DIR=/path/to/nomad-simulations
+# optional: override the default base package used in UI helpers
+# export SCHEMA_UML_BASE_PACKAGE=my_schema_root
+# optional: override the default package used in UI helpers
+# export SCHEMA_UML_PACKAGE=my_schema_root.module
 ```
 Make it persistent by adding the export to `~/.bashrc` or `~/.zshrc`.
-
-The repository should be under `nomad-simulations/` folder. Custom module names are not yet supported. 
 
 ### 4) Backend (FastAPI)
 ```bash
@@ -63,7 +66,6 @@ curl 'http://127.0.0.1:5179/schema?package=nomad_simulations.schema_packages.mod
 curl 'http://127.0.0.1:5179/git/branches'
 ```
 
-(REMINDER: The repository should be under `nomad-simulations/` folder. Custom module names are not yet supported.)
 
 ### 5) Frontend (Vite dev server)
 ```bash

--- a/REPO_GUIDE.md
+++ b/REPO_GUIDE.md
@@ -6,7 +6,7 @@ A structured overview of the repository for developers to navigate, understand, 
 
 ## 0) TL;DR
 
-**Purpose:** Visualize `nomad-simulations` schema as UML diagrams, inspect docstrings and normalization helpers, and compare schema changes across Git branches.
+**Purpose:** Visualize NOMAD-compatible schemas (defaults to `nomad-simulations`) as UML diagrams, inspect docstrings and normalization helpers, and compare schema changes across Git branches.
 
 **Frontend:** React + TypeScript + Cytoscape + ELK  
 **Backend:** FastAPI + GitPython
@@ -28,9 +28,13 @@ A structured overview of the repository for developers to navigate, understand, 
 
 **Environment variables (one of):**
 ~~~bash
+export SCHEMA_UML_REPO=/path/to/your-schema
+# or (legacy envs still supported)
 export NOMAD_SIM_REPO=/path/to/nomad-simulations
-# or
 export GIT_REPO_DIR=/path/to/nomad-simulations
+# optional defaults for base package / module when the UI opens
+export SCHEMA_UML_BASE_PACKAGE=my_schema_root
+export SCHEMA_UML_PACKAGE=my_schema_root.module
 ~~~
 
 **UX highlights:**
@@ -353,13 +357,13 @@ The frontend shows these entries as a list under **Under the hood** for the curr
 **Bare mirror location**
 
 ~~~text
-api/_data/nomad-simulations.bare
+api/_data/<repo-slug>.bare  # slug derived from SCHEMA_UML_REPO
 ~~~
 
 **Worktrees**
 
 ~~~text
-api/_data/nomad-simulations.bare/worktrees/<branch>/...
+api/_data/<repo-slug>.bare/worktrees/<branch>/...
 ~~~
 
 **Rebuild mirror safely**
@@ -369,7 +373,14 @@ rm -rf api/_data
 mkdir -p api/_data
 (
   cd api/_data &&
-  git clone --bare "$NOMAD_SIM_REPO" nomad-simulations.bare
+  git clone --bare "$SCHEMA_UML_REPO" $(python - <<'PY'
+import os, re
+from urllib.parse import urlparse
+from pathlib import Path
+src = os.environ.get("SCHEMA_UML_REPO") or os.environ.get("NOMAD_SIM_REPO")
+name = Path(urlparse(src).path or src).name
+print(re.sub(r"[^A-Za-z0-9._-]", "_", name[:-4] if name.endswith('.git') else name))
+PY)
 )
 ~~~
 

--- a/api/git_utils.py
+++ b/api/git_utils.py
@@ -3,17 +3,17 @@ from pathlib import Path
 from typing import List, Tuple
 import shutil
 from git import Repo, GitCommandError
-from .settings import DATA_DIR, NOMAD_SIM_REPO
+from .settings import DATA_DIR, SCHEMA_REPO, REPO_SLUG
 
-BARE_DIR = Path(DATA_DIR) / "nomad-simulations.bare"
+BARE_DIR = Path(DATA_DIR) / f"{REPO_SLUG}.bare"
 WT_DIR   = Path(DATA_DIR) / "worktrees"
 WT_DIR.mkdir(parents=True, exist_ok=True)
 
 def ensure_bare() -> Repo:
     """Make sure we have a bare mirror of the repo with all branches fetched."""
-    src = NOMAD_SIM_REPO
+    src = SCHEMA_REPO
     if not Path(src, ".git").exists() and not (Path(src).is_dir() and (Path(src) / "HEAD").exists()):
-        raise RuntimeError(f"NOMAD_SIM_REPO={src} is not a git repository")
+        raise RuntimeError("Set SCHEMA_UML_REPO / NOMAD_SIM_REPO / GIT_REPO_DIR to a git repository")
 
     if BARE_DIR.exists():
         repo = Repo(str(BARE_DIR))

--- a/api/graph_runner.py
+++ b/api/graph_runner.py
@@ -34,7 +34,7 @@ def build_graph_in_subprocess(
 ) -> Dict[str, Any]:
     env = os.environ.copy()
 
-    # Make nomad-simulations worktree importable AND this app’s modules (extractor/*)
+    # Make the schema worktree importable AND this app’s modules (extractor/*)
     py_paths = [
         str(worktree),
         str(worktree / "src"),

--- a/api/main.py
+++ b/api/main.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel
 
 from .routes_git import router as git_router
 from extractor.usage_index import UsageEntry, get_usage_for_section
+from .settings import SCHEMA_REPO, DEFAULT_BASE_PACKAGE
 
 SUPPORTED_CUSTOM_DTYPES = {
     "bool",
@@ -69,10 +70,11 @@ def schema(
 
 
 def _repo_root() -> Path:
-    root = os.environ.get("NOMAD_SIM_REPO") or os.environ.get("GIT_REPO_DIR")
-    if not root:
-        raise RuntimeError("Set NOMAD_SIM_REPO or GIT_REPO_DIR to a local clone of nomad-simulations")
-    return Path(root).resolve()
+    if not SCHEMA_REPO:
+        raise RuntimeError(
+            "Set SCHEMA_UML_REPO / NOMAD_SIM_REPO / GIT_REPO_DIR to a local schema clone"
+        )
+    return Path(SCHEMA_REPO).resolve()
 
 def _run_git(repo: Path, *args: str) -> str:
     cp = subprocess.run(["git", "-C", str(repo), *args], capture_output=True, text=True)
@@ -254,7 +256,7 @@ def add_custom_quantity(
 @app.get("/overview", response_model=OverviewOut)
 def overview(
     branch: str = Query("develop"),
-    base: str = Query("nomad_simulations.schema_packages"),
+    base: str = Query(DEFAULT_BASE_PACKAGE),
 ):
     """
     Bird's-eye overview: packages under `base` and their top-level classes at `branch`.

--- a/api/routes_git.py
+++ b/api/routes_git.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
 from pathlib import Path
 from typing import Optional, List
-from .settings import DEFAULT_PACKAGE
+from .settings import DEFAULT_PACKAGE, DEFAULT_BASE_PACKAGE
 from .git_utils import list_branches, materialize_worktree
 from .graph_runner import build_graph_in_subprocess
 from .diff import diff_graphs
@@ -28,7 +28,7 @@ def _python_root(wt: Path) -> Path:
     """
     Return the directory under which Python packages live in the worktree.
 
-    In nomad-simulations this is typically <worktree>/src.
+    In many NOMAD schemas this is typically <worktree>/src.
     If that does not exist, fall back to the worktree root.
     """
     src = wt / "src"
@@ -77,7 +77,7 @@ def api_branches():
 @router.get("/git/packages")
 def api_packages(
     branch: str = Query("develop"),
-    base_package: str = Query("nomad_simulations.schema_packages"),
+    base_package: str = Query(DEFAULT_BASE_PACKAGE),
 ):
     """
     List Python modules under `base_package` for the given branch.

--- a/api/settings.py
+++ b/api/settings.py
@@ -1,14 +1,37 @@
 from pathlib import Path
+from urllib.parse import urlparse
 import os
+import re
 
 # Where to keep a bare clone + worktrees
 DATA_DIR = Path(os.getenv("SCHEMA_UML_DATA_DIR", Path(__file__).resolve().parent / "_data"))
 DATA_DIR.mkdir(parents=True, exist_ok=True)
 
-# Local path or remote URL to your nomad-simulations repo
-NOMAD_SIM_REPO = os.getenv("NOMAD_SIM_REPO", str(Path.home() / "src/nomad-simulations"))
+# Local path or remote URL to the schema repository (supports NOMAD-compatible schemas)
+SCHEMA_REPO = (
+    os.getenv("SCHEMA_UML_REPO")
+    or os.getenv("NOMAD_SIM_REPO")
+    or os.getenv("GIT_REPO_DIR")
+    or str(Path.home() / "src/nomad-simulations")
+)
 
-# Python module you extract from (can be overridden per request)
-DEFAULT_PACKAGE = os.getenv("SCHEMA_UML_PACKAGE", "nomad_simulations.model_method")
+
+def _repo_slug(src: str) -> str:
+    """Return a filesystem-friendly slug for the bare mirror."""
+
+    path = urlparse(src).path or src
+    name = Path(path).name or "schema-repo"
+    if name.endswith(".git"):
+        name = name[:-4]
+    # Keep alnum + separators stable
+    name = re.sub(r"[^A-Za-z0-9._-]", "_", name)
+    return name or "schema-repo"
+
+
+REPO_SLUG = _repo_slug(SCHEMA_REPO)
+
+# Default base package/section can be overridden per request or via env vars
+DEFAULT_BASE_PACKAGE = os.getenv("SCHEMA_UML_BASE_PACKAGE", "nomad_simulations.schema_packages")
+DEFAULT_PACKAGE = os.getenv("SCHEMA_UML_PACKAGE", f"{DEFAULT_BASE_PACKAGE}.model_method")
 
 EXTRACTOR_ENTRY = os.getenv("SCHEMA_UML_EXTRACTOR", "extractor.graph_builder:build_graph")

--- a/extractor/graph_builder.py
+++ b/extractor/graph_builder.py
@@ -107,7 +107,7 @@ def build_graph(
             return
 
         # collect methods defined in your package
-        methods = _public_methods(sec_obj)
+        methods = _public_methods(sec_obj, base_namespace)
 
         # robust doc extraction
         doc = _doc_from(sec_obj)
@@ -331,14 +331,15 @@ def _module_in_namespace(obj, package_namespace: str) -> bool:
     return mod.startswith(package_namespace)
 
 
-def _public_methods(sec_obj) -> List[str]:
-    """Only public methods implemented under 'nomad_simulations*'."""
+def _public_methods(sec_obj, base_namespace: Optional[str] = None) -> List[str]:
+    """Only public methods implemented under the active base namespace."""
+    base = base_namespace or _root_namespace(getattr(sec_obj, "__module__", ""))
     names = []
     for name, member in inspect.getmembers(sec_obj, predicate=inspect.isfunction):
         if name.startswith("_"):
             continue
         mod = getattr(member, "__module__", "")
-        if not mod.startswith("nomad_simulations"):
+        if base and not mod.startswith(base):
             continue
         names.append(name)
     return sorted(set(names))

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -16,20 +16,24 @@ type ApiGraph = {
 };
 
 const DEFAULT_API = "http://localhost:5179";
+const DEFAULT_PACKAGE = import.meta.env.VITE_DEFAULT_PACKAGE ?? "nomad_simulations.schema_packages.model_method";
+const DEFAULT_NAMESPACE = import.meta.env.VITE_DEFAULT_NAMESPACE ?? "nomad_simulations.schema_packages";
+const DEFAULT_ROOT = import.meta.env.VITE_DEFAULT_ROOT ?? "ModelMethod";
+const DEFAULT_BRANCH = import.meta.env.VITE_DEFAULT_BRANCH ?? "develop";
 
 export default function App() {
   const [apiBase, setApiBase] = useState<string>(DEFAULT_API);
-  const [pkg, setPkg] = useState<string>("nomad_simulations.schema_packages.model_method");
+  const [pkg, setPkg] = useState<string>(DEFAULT_PACKAGE);
   const [availablePkgs, setAvailablePkgs] = useState<string[]>([]);
   const [roots, setRoots] = useState<string[]>([]);
-  const [root, setRoot] = useState<string>("ModelMethod");
+  const [root, setRoot] = useState<string>(DEFAULT_ROOT);
 
   const [includeQuantities, setIncludeQuantities] = useState<boolean>(true);
   const [includeSubsections, setIncludeSubsections] = useState<boolean>(true);
   const [umlMode, setUmlMode] = useState<boolean>(true);
 
   const [crossModules, setCrossModules] = useState<boolean>(true);
-  const [namespace, setNamespace] = useState<string>("nomad_simulations.schema_packages");
+  const [namespace, setNamespace] = useState<string>(DEFAULT_NAMESPACE);
 
   const [graph, setGraph] = useState<ApiGraph | null>(null);
   const [loading, setLoading] = useState<boolean>(false);
@@ -53,7 +57,7 @@ export default function App() {
 
   // overview mode
   const [mode, setMode] = useState<"graph" | "overview">("graph");
-  const [overviewBranch, setOverviewBranch] = useState<string>("develop");
+  const [overviewBranch, setOverviewBranch] = useState<string>(DEFAULT_BRANCH);
 
   const api = useMemo(() => axios.create({ baseURL: apiBase }), [apiBase]);
 
@@ -113,8 +117,8 @@ export default function App() {
     try {
       const r = await api.get("/git/packages", {
         params: {
-          branch: "develop",
-          base_package: "nomad_simulations.schema_packages",
+          branch: DEFAULT_BRANCH,
+          base_package: namespace || DEFAULT_NAMESPACE,
         },
       });
       const list: string[] = r.data.packages || [];
@@ -300,7 +304,7 @@ export default function App() {
                 value={overviewBranch}
                 onChange={(e) => setOverviewBranch(e.target.value)}
               >
-                {["develop", ...branches.filter((b) => b !== "develop")].map((b) => (
+                {[DEFAULT_BRANCH, ...branches.filter((b) => b !== DEFAULT_BRANCH)].map((b) => (
                   <option key={b} value={b}>{b}</option>
                 ))}
               </select>
@@ -325,13 +329,13 @@ export default function App() {
           className="input"
           value={pkg}
           onChange={(e) => setPkg(e.target.value)}
-          placeholder="nomad_simulations.schema_packages.model_method"
+          placeholder={DEFAULT_PACKAGE}
         />
 
         {availablePkgs.length > 0 && (
           <>
             <label className="label" style={{ marginTop: 8 }}>
-              Choose from develop
+              Choose from {DEFAULT_BRANCH}
             </label>
             <select
               className="select"
@@ -416,7 +420,7 @@ export default function App() {
           className="input"
           value={namespace}
           onChange={(e) => setNamespace(e.target.value)}
-          placeholder="nomad_simulations.schema_packages"
+          placeholder={DEFAULT_NAMESPACE}
         />
 
         <div className="row" style={{ marginTop: 10 }}>
@@ -524,7 +528,7 @@ export default function App() {
         <div style={{ minWidth: 0 }}>
           {mode === "overview" ? (
             //<OverviewList apiBase={apiBase} branch={overviewBranch} />
-            <OverviewGrid apiBase={apiBase} branch={overviewBranch} />
+            <OverviewGrid apiBase={apiBase} branch={overviewBranch} base={namespace || DEFAULT_NAMESPACE} />
           ) : diffData ? (
             <>
               <div

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,4 +1,5 @@
 const BASE = import.meta.env.VITE_API_BASE ?? "http://localhost:5179";
+const DEFAULT_PACKAGE = import.meta.env.VITE_DEFAULT_PACKAGE ?? "nomad_simulations.schema_packages.model_method";
 
 export async function listBranches(): Promise<string[]> {
   const r = await fetch(`${BASE}/git/branches`);
@@ -28,7 +29,7 @@ export type DiffResponse = {
   };
 };
 
-export async function getDiff(base: string, head: string, pkg = "nomad_simulations.model_method") {
+export async function getDiff(base: string, head: string, pkg = DEFAULT_PACKAGE) {
   const r = await fetch(`${BASE}/graph/diff`, {
     method: "POST",
     headers: { "content-type": "application/json" },

--- a/web/src/components/OverviewGrid.tsx
+++ b/web/src/components/OverviewGrid.tsx
@@ -3,10 +3,12 @@ import { useEffect, useMemo, useState } from "react";
 type OverviewItem = { package: string; classes: string[] };
 type OverviewResp = { branch: string; base: string; items: OverviewItem[] };
 
+const DEFAULT_OVERVIEW_BASE = import.meta.env.VITE_DEFAULT_NAMESPACE ?? "nomad_simulations.schema_packages";
+
 export default function OverviewGrid({
   apiBase,
   branch,
-  base = "nomad_simulations.schema_packages",
+  base = DEFAULT_OVERVIEW_BASE,
 }: {
   apiBase: string;
   branch: string;

--- a/web/src/components/OverviewList.tsx
+++ b/web/src/components/OverviewList.tsx
@@ -3,10 +3,12 @@ import { useEffect, useState } from "react";
 type OverviewItem = { package: string; classes: string[] };
 type OverviewResp = { branch: string; base: string; items: OverviewItem[] };
 
+const DEFAULT_OVERVIEW_BASE = import.meta.env.VITE_DEFAULT_NAMESPACE ?? "nomad_simulations.schema_packages";
+
 export default function OverviewList({
   apiBase,
   branch,
-  base = "nomad_simulations.schema_packages",
+  base = DEFAULT_OVERVIEW_BASE,
 }: {
   apiBase: string;
   branch: string;


### PR DESCRIPTION
## Summary
- allow configuring the schema repository slug and default packages through new environment variables instead of assuming nomad-simulations
- expose configurable defaults across backend endpoints and frontend UI so other NOMAD-compatible schemas can be browsed
- update documentation to explain the broader schema support and configuration knobs

## Testing
- python -m compileall api extractor

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929769be2388320b6354376f0bf9093)