### PR TITLE
Add unified dev script for backend and frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ What it does:
 - Starts the FastAPI backend on **5179**.
 - Ensures `web/node_modules` exists (runs `npm install` on first launch).
 - Starts the Vite frontend on **5173**.
+- Stops both together on **Ctrl+C** (no manual job control needed).
+- Exits early with a helpful message if `uvicorn` or `npm` are missing (activate your virtualenv first).
 
 Stop both with **Ctrl+C**. Override ports via `API_PORT` / `WEB_PORT` env vars.
 

--- a/README.md
+++ b/README.md
@@ -60,26 +60,25 @@ export SCHEMA_UML_REPO=<path-or-URL-to-your-schema-repo>
 ```
 Make it persistent by adding the export to `~/.bashrc` or `~/.zshrc`.
 
-### 4) Backend (FastAPI)
+### 4) Run everything with one command
 ```bash
-uvicorn api.main:app --reload --port 5179
+./dev.sh
 ```
 
-Sanity checks:
+What it does:
+
+- Starts the FastAPI backend on **5179**.
+- Ensures `web/node_modules` exists (runs `npm install` on first launch).
+- Starts the Vite frontend on **5173**.
+
+Stop both with **Ctrl+C**. Override ports via `API_PORT` / `WEB_PORT` env vars.
+
+Sanity checks (optional, while `./dev.sh` is running):
 ```bash
 curl 'http://127.0.0.1:5179/roots?package=nomad_simulations.schema_packages.model_method'
 curl 'http://127.0.0.1:5179/schema?package=nomad_simulations.schema_packages.model_method&root=ModelMethod&include_quantities=true'
 curl 'http://127.0.0.1:5179/git/branches'
 ```
-
-
-### 5) Frontend (Vite dev server)
-```bash
-cd web
-npm install
-npm run dev
-```
-Open: <http://localhost:5173/>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Make it persistent by adding the export to `~/.bashrc` or `~/.zshrc`.
 What it does:
 
 - Starts the FastAPI backend on **5179**.
-- Verifies **SCHEMA_UML_REPO / NOMAD_SIM_REPO / GIT_REPO_DIR** points to a **local git repo** (fails fast otherwise).
+- Verifies **SCHEMA_UML_REPO / NOMAD_SIM_REPO / GIT_REPO_DIR** points to a **local git repo** (a subdirectory of a clone is fine; fails fast otherwise).
 - Ensures `web/node_modules` exists (runs `npm install` on first launch).
 - Starts the Vite frontend on **5173**.
 - Stops both together on **Ctrl+C** (no manual job control needed).

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ pip install -r requirements.txt
 ```
 
 ### 3) Point to your schema repo
-The backend reads from a local clone. Set one of:
+The backend reads from a local clone. Set one of (required before starting the stack):
 ```bash
 # preferred (general)
 export SCHEMA_UML_REPO=<path-or-URL-to-your-schema-repo>
@@ -68,6 +68,7 @@ Make it persistent by adding the export to `~/.bashrc` or `~/.zshrc`.
 What it does:
 
 - Starts the FastAPI backend on **5179**.
+- Verifies **SCHEMA_UML_REPO / NOMAD_SIM_REPO / GIT_REPO_DIR** points to a **local git repo** (fails fast otherwise).
 - Ensures `web/node_modules` exists (runs `npm install` on first launch).
 - Starts the Vite frontend on **5173**.
 - Stops both together on **Ctrl+C** (no manual job control needed).

--- a/REPO_GUIDE.md
+++ b/REPO_GUIDE.md
@@ -37,7 +37,7 @@ export SCHEMA_UML_BASE_PACKAGE=my_schema_root
 export SCHEMA_UML_PACKAGE=my_schema_root.module
 ~~~
 
-**Unified dev command:** `./dev.sh` starts the FastAPI backend (**5179**) and Vite frontend (**5173**), checks for `uvicorn`/`npm`, installs frontend deps on first run, and stops both on **Ctrl+C**. Override ports via `API_PORT` / `WEB_PORT`.
+**Unified dev command:** `./dev.sh` starts the FastAPI backend (**5179**) and Vite frontend (**5173**), checks for `uvicorn`/`npm`, validates **SCHEMA_UML_REPO / NOMAD_SIM_REPO / GIT_REPO_DIR** points to a local git repo, installs frontend deps on first run, and stops both on **Ctrl+C**. Override ports via `API_PORT` / `WEB_PORT`.
 
 **UX highlights:**
 - UML cards show **sections**; **quantities** appear as attributes inside the card (not separate nodes).

--- a/REPO_GUIDE.md
+++ b/REPO_GUIDE.md
@@ -37,7 +37,7 @@ export SCHEMA_UML_BASE_PACKAGE=my_schema_root
 export SCHEMA_UML_PACKAGE=my_schema_root.module
 ~~~
 
-**Unified dev command:** `./dev.sh` starts the FastAPI backend (**5179**) and Vite frontend (**5173**), checks for `uvicorn`/`npm`, validates **SCHEMA_UML_REPO / NOMAD_SIM_REPO / GIT_REPO_DIR** points to a local git repo, installs frontend deps on first run, and stops both on **Ctrl+C**. Override ports via `API_PORT` / `WEB_PORT`.
+**Unified dev command:** `./dev.sh` starts the FastAPI backend (**5179**) and Vite frontend (**5173**), checks for `uvicorn`/`npm`, validates **SCHEMA_UML_REPO / NOMAD_SIM_REPO / GIT_REPO_DIR** points to a local git repo (a subdirectory of a clone is fine), installs frontend deps on first run, and stops both on **Ctrl+C**. Override ports via `API_PORT` / `WEB_PORT`.
 
 **UX highlights:**
 - UML cards show **sections**; **quantities** appear as attributes inside the card (not separate nodes).

--- a/REPO_GUIDE.md
+++ b/REPO_GUIDE.md
@@ -37,7 +37,7 @@ export SCHEMA_UML_BASE_PACKAGE=my_schema_root
 export SCHEMA_UML_PACKAGE=my_schema_root.module
 ~~~
 
-**Unified dev command:** `./dev.sh` starts the FastAPI backend (**5179**) and Vite frontend (**5173**), installs frontend deps on first run, and stops both on **Ctrl+C**. Override ports via `API_PORT` / `WEB_PORT`.
+**Unified dev command:** `./dev.sh` starts the FastAPI backend (**5179**) and Vite frontend (**5173**), checks for `uvicorn`/`npm`, installs frontend deps on first run, and stops both on **Ctrl+C**. Override ports via `API_PORT` / `WEB_PORT`.
 
 **UX highlights:**
 - UML cards show **sections**; **quantities** appear as attributes inside the card (not separate nodes).

--- a/REPO_GUIDE.md
+++ b/REPO_GUIDE.md
@@ -37,8 +37,10 @@ export SCHEMA_UML_BASE_PACKAGE=my_schema_root
 export SCHEMA_UML_PACKAGE=my_schema_root.module
 ~~~
 
+**Unified dev command:** `./dev.sh` starts the FastAPI backend (**5179**) and Vite frontend (**5173**), installs frontend deps on first run, and stops both on **Ctrl+C**. Override ports via `API_PORT` / `WEB_PORT`.
+
 **UX highlights:**
-- UML cards show **sections**; **quantities** appear as attributes inside the card (not separate nodes).  
+- UML cards show **sections**; **quantities** appear as attributes inside the card (not separate nodes).
 - Right **Doc Panel** shows the **class docstring** and a **clickable list of quantities**; clicking a quantity shows its docstring.  
 - Right **Under-the-hood Panel** shows **normalization methods and helper functions** that act on the selected section (based on `/usage`).  
 - Branch diff highlights: 🟩 Added, 🟨 Changed, 🟥 Removed (edges dashed red).

--- a/dev.sh
+++ b/dev.sh
@@ -90,15 +90,25 @@ cd "${ROOT_DIR}"
 
 echo "Both services launched. Press Ctrl+C to stop."
 
-# Wait until one of the services exits (or the user hits Ctrl+C)
+# Wait until one of the services exits (or the user hits Ctrl+C). macOS ships with
+# Bash 3.x, which lacks `wait -n`, so poll the processes for portability.
+status_api=""
+status_web=""
 while true; do
-  if ! wait -n; then
-    echo "A service stopped with a non-zero exit code. Shutting down the stack..."
+  if [[ -z "${status_api}" ]] && ! ps -p "${API_PID}" >/dev/null 2>&1; then
+    wait "${API_PID}" || status_api=$?
     break
   fi
-  # If we reach here, a service exited cleanly (unlikely during dev); continue waiting.
-  if ! ps -p "${API_PID}" >/dev/null 2>&1 || ! ps -p "${WEB_PID}" >/dev/null 2>&1; then
+
+  if [[ -z "${status_web}" ]] && ! ps -p "${WEB_PID}" >/dev/null 2>&1; then
+    wait "${WEB_PID}" || status_web=$?
     break
   fi
+
+  sleep 1
 done
+
+if [[ -n "${status_api}" || -n "${status_web}" ]]; then
+  echo "A service stopped with a non-zero exit code. Shutting down the stack..."
+fi
 

--- a/dev.sh
+++ b/dev.sh
@@ -14,6 +14,7 @@ need_cmd() {
   fi
 }
 
+need_cmd git
 need_cmd uvicorn
 need_cmd npm
 
@@ -44,10 +45,10 @@ EOF
     exit 1
   fi
 
-  if [[ ! -d "${repo_path}/.git" && ! -f "${repo_path}/HEAD" ]]; then
+  if ! git -C "${repo_path}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     cat <<EOF
 Error: '${repo_path}' is not a git repository.
-- Point SCHEMA_UML_REPO (or NOMAD_SIM_REPO / GIT_REPO_DIR) to a local clone.
+- Point SCHEMA_UML_REPO (or NOMAD_SIM_REPO / GIT_REPO_DIR) to a local clone (a subdirectory of a clone is fine).
 EOF
     exit 1
   fi

--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Unified dev runner for backend (FastAPI) + frontend (Vite)
+set -euo pipefail
+
+ROOT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+API_PORT="${API_PORT:-5179}"
+WEB_PORT="${WEB_PORT:-5173}"
+
+cleanup() {
+  trap - EXIT
+  for pid in "${API_PID:-}" "${WEB_PID:-}"; do
+    if [[ -n "${pid}" ]] && ps -p "${pid}" > /dev/null 2>&1; then
+      kill "${pid}" 2>/dev/null || true
+    fi
+  done
+}
+
+trap cleanup EXIT
+
+echo "Starting FastAPI backend on :${API_PORT}..."
+uvicorn --app-dir "${ROOT_DIR}" api.main:app --reload --port "${API_PORT}" &
+API_PID=$!
+
+cd "${ROOT_DIR}/web"
+if [[ ! -d node_modules ]]; then
+  echo "Installing frontend dependencies (web/node_modules not found)..."
+  npm install
+fi
+
+echo "Starting Vite frontend on :${WEB_PORT}..."
+npm run dev -- --host --port "${WEB_PORT}" &
+WEB_PID=$!
+
+cd "${ROOT_DIR}"
+
+# Wait until one of the services exits (or the user hits Ctrl+C)
+if ! wait -n; then
+  echo "A service stopped with a non-zero exit code. Shutting down the stack..."
+fi

--- a/dev.sh
+++ b/dev.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 ROOT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 API_PORT="${API_PORT:-5179}"
 WEB_PORT="${WEB_PORT:-5173}"
+DEFAULT_SCHEMA_REPO="${HOME}/src/nomad-simulations"
 
 need_cmd() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -15,6 +16,44 @@ need_cmd() {
 
 need_cmd uvicorn
 need_cmd npm
+
+resolve_schema_repo() {
+  # Mirrors api/settings.py resolution order
+  local candidate
+  for var in SCHEMA_UML_REPO NOMAD_SIM_REPO GIT_REPO_DIR; do
+    candidate=${!var-}
+    if [[ -n "${candidate}" ]]; then
+      echo "${candidate}"
+      return 0
+    fi
+  done
+
+  echo "${DEFAULT_SCHEMA_REPO}"
+}
+
+validate_schema_repo() {
+  local repo_path
+  repo_path="$(resolve_schema_repo)"
+
+  if [[ ! -d "${repo_path}" ]]; then
+    cat <<EOF
+Error: Could not find a schema repository.
+- Set one of SCHEMA_UML_REPO / NOMAD_SIM_REPO / GIT_REPO_DIR to a local git clone.
+- Current default (${DEFAULT_SCHEMA_REPO}) does not exist.
+EOF
+    exit 1
+  fi
+
+  if [[ ! -d "${repo_path}/.git" && ! -f "${repo_path}/HEAD" ]]; then
+    cat <<EOF
+Error: '${repo_path}' is not a git repository.
+- Point SCHEMA_UML_REPO (or NOMAD_SIM_REPO / GIT_REPO_DIR) to a local clone.
+EOF
+    exit 1
+  fi
+
+  echo "Using schema repo: ${repo_path}"
+}
 
 cleanup() {
   trap - EXIT INT TERM
@@ -28,6 +67,8 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 cd "${ROOT_DIR}"
+
+validate_schema_repo
 
 echo "Starting FastAPI backend on :${API_PORT}..."
 uvicorn --app-dir "${ROOT_DIR}" api.main:app --reload --port "${API_PORT}" &

--- a/dev.sh
+++ b/dev.sh
@@ -6,8 +6,18 @@ ROOT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 API_PORT="${API_PORT:-5179}"
 WEB_PORT="${WEB_PORT:-5173}"
 
+need_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Error: '$1' not found. Please install it (or activate your virtualenv) and retry." >&2
+    exit 1
+  fi
+}
+
+need_cmd uvicorn
+need_cmd npm
+
 cleanup() {
-  trap - EXIT
+  trap - EXIT INT TERM
   for pid in "${API_PID:-}" "${WEB_PID:-}"; do
     if [[ -n "${pid}" ]] && ps -p "${pid}" > /dev/null 2>&1; then
       kill "${pid}" 2>/dev/null || true
@@ -15,12 +25,15 @@ cleanup() {
   done
 }
 
-trap cleanup EXIT
+trap cleanup EXIT INT TERM
+
+cd "${ROOT_DIR}"
 
 echo "Starting FastAPI backend on :${API_PORT}..."
 uvicorn --app-dir "${ROOT_DIR}" api.main:app --reload --port "${API_PORT}" &
 API_PID=$!
 
+echo "Switching to frontend (web/)"
 cd "${ROOT_DIR}/web"
 if [[ ! -d node_modules ]]; then
   echo "Installing frontend dependencies (web/node_modules not found)..."
@@ -33,7 +46,17 @@ WEB_PID=$!
 
 cd "${ROOT_DIR}"
 
+echo "Both services launched. Press Ctrl+C to stop."
+
 # Wait until one of the services exits (or the user hits Ctrl+C)
-if ! wait -n; then
-  echo "A service stopped with a non-zero exit code. Shutting down the stack..."
-fi
+while true; do
+  if ! wait -n; then
+    echo "A service stopped with a non-zero exit code. Shutting down the stack..."
+    break
+  fi
+  # If we reach here, a service exited cleanly (unlikely during dev); continue waiting.
+  if ! ps -p "${API_PID}" >/dev/null 2>&1 || ! ps -p "${WEB_PID}" >/dev/null 2>&1; then
+    break
+  fi
+done
+


### PR DESCRIPTION
## Summary
- add a dev.sh helper to start FastAPI and Vite together, installing frontend deps on first run
- document the one-command startup flow in README and REPO_GUIDE, including port overrides and sanity checks

## Testing
- bash -n dev.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692aa18c6d1c8320a053bdeaca03e80b)