### PR TITLE
Support multiple NOMAD base packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ The backend reads from a local clone. Set one of (required before starting the s
 ```bash
 # preferred (general)
 export SCHEMA_UML_REPO=<path-or-URL-to-your-schema-repo>
+# optional: explicitly point to nomad-measurements when using both namespaces
+# export NOMAD_MEASURE_REPO=/path/to/nomad-measurements
 # backwards-compatible options also accepted by backend
 # export NOMAD_SIM_REPO=/path/to/nomad-simulations
 # export GIT_REPO_DIR=/path/to/nomad-simulations

--- a/api/git_utils.py
+++ b/api/git_utils.py
@@ -3,38 +3,44 @@ from pathlib import Path
 from typing import List, Tuple
 import shutil
 from git import Repo, GitCommandError
-from .settings import DATA_DIR, SCHEMA_REPO, REPO_SLUG
+from .settings import DATA_DIR, SCHEMA_REPO, _repo_slug
 
-BARE_DIR = Path(DATA_DIR) / f"{REPO_SLUG}.bare"
-WT_DIR   = Path(DATA_DIR) / "worktrees"
-WT_DIR.mkdir(parents=True, exist_ok=True)
+def _bare_dir(src: str) -> Path:
+    return Path(DATA_DIR) / f"{_repo_slug(src)}.bare"
 
-def ensure_bare() -> Repo:
+
+def _wt_dir(src: str) -> Path:
+    root = Path(DATA_DIR) / "worktrees" / _repo_slug(src)
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+def ensure_bare(src: str = SCHEMA_REPO) -> Repo:
     """Make sure we have a bare mirror of the repo with all branches fetched."""
-    src = SCHEMA_REPO
-    if not Path(src, ".git").exists() and not (Path(src).is_dir() and (Path(src) / "HEAD").exists()):
-        raise RuntimeError("Set SCHEMA_UML_REPO / NOMAD_SIM_REPO / GIT_REPO_DIR to a git repository")
+    bare_dir = _bare_dir(src)
 
-    if BARE_DIR.exists():
-        repo = Repo(str(BARE_DIR))
+    if not Path(src, ".git").exists() and not (Path(src).is_dir() and (Path(src) / "HEAD").exists()):
+        raise RuntimeError("Set SCHEMA_UML_REPO / NOMAD_SIM_REPO / NOMAD_MEASURE_REPO / GIT_REPO_DIR to a git repository")
+
+    if bare_dir.exists():
+        repo = Repo(str(bare_dir))
         try:
             repo.git.fetch("--all", "--prune")
         except Exception as e:
             print("DEBUG: fetch failed, recreating bare repo:", e)
-            shutil.rmtree(BARE_DIR)
-            repo = Repo.clone_from(src, str(BARE_DIR), bare=True)
+            shutil.rmtree(bare_dir)
+            repo = Repo.clone_from(src, str(bare_dir), bare=True)
         return repo
 
     # First-time clone
-    print(f"DEBUG: Cloning bare mirror from {src} → {BARE_DIR}")
-    repo = Repo.clone_from(src, str(BARE_DIR), bare=True)
+    print(f"DEBUG: Cloning bare mirror from {src} → {bare_dir}")
+    repo = Repo.clone_from(src, str(bare_dir), bare=True)
     repo.git.fetch("--all", "--prune")
     return repo
 
 
-def list_branches() -> List[str]:
+def list_branches(src: str = SCHEMA_REPO) -> List[str]:
     """Return all local + remote branches available in the mirrored repo."""
-    repo = ensure_bare()
+    repo = ensure_bare(src)
     names = set()
 
     # include local branches
@@ -52,12 +58,12 @@ def list_branches() -> List[str]:
     print("DEBUG: branches seen by backend:", sorted(names))
     return sorted(names)
 
-def materialize_worktree(branch: str) -> Tuple[Path, str]:
+def materialize_worktree(branch: str, src: str = SCHEMA_REPO) -> Tuple[Path, str]:
     """
     Create or update a worktree for the given branch.
     Works both for local branches and bare mirrors without remotes.
     """
-    repo = ensure_bare()
+    repo = ensure_bare(src)
 
     # make sure refs exist locally
     try:
@@ -75,7 +81,8 @@ def materialize_worktree(branch: str) -> Tuple[Path, str]:
         except Exception as e:
             raise RuntimeError(f"Branch '{branch}' not found in bare repo ({repo.git_dir}): {e}")
 
-    wt = WT_DIR / branch.replace("/", "__")
+    wt_root = _wt_dir(src)
+    wt = wt_root / branch.replace("/", "__")
 
     # recreate if stale
     if wt.exists():

--- a/api/main.py
+++ b/api/main.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel
 
 from .routes_git import router as git_router
 from extractor.usage_index import UsageEntry, get_usage_for_section
-from .settings import SCHEMA_REPO, DEFAULT_BASE_PACKAGE
+from .settings import SCHEMA_REPO, DEFAULT_BASE_PACKAGE, repo_for_base_namespace
 
 SUPPORTED_CUSTOM_DTYPES = {
     "bool",
@@ -69,12 +69,23 @@ def schema(
     return data
 
 
-def _repo_root() -> Path:
-    if not SCHEMA_REPO:
+def _repo_root(base_package: str | None = None) -> Path:
+    if base_package:
+        repo_src = repo_for_base_namespace(base_package)
+    else:
+        repo_src = SCHEMA_REPO
+
+    if not repo_src:
         raise RuntimeError(
-            "Set SCHEMA_UML_REPO / NOMAD_SIM_REPO / GIT_REPO_DIR to a local schema clone"
+            "Set SCHEMA_UML_REPO / NOMAD_SIM_REPO / NOMAD_MEASURE_REPO / GIT_REPO_DIR to a local schema clone"
         )
-    return Path(SCHEMA_REPO).resolve()
+
+    repo_path = Path(repo_src).expanduser().resolve()
+    if not (repo_path / ".git").exists():
+        raise RuntimeError(
+            "Set SCHEMA_UML_REPO / NOMAD_SIM_REPO / NOMAD_MEASURE_REPO / GIT_REPO_DIR to a local schema clone"
+        )
+    return repo_path
 
 def _run_git(repo: Path, *args: str) -> str:
     cp = subprocess.run(["git", "-C", str(repo), *args], capture_output=True, text=True)
@@ -270,7 +281,6 @@ def overview(
     Resolves repo layout prefixes (e.g., src/).
     """
     try:
-        repo = _repo_root()
         base_packages = _parse_base_packages(base)
         if not base_packages:
             raise HTTPException(status_code=400, detail="Provide at least one base package")
@@ -278,6 +288,7 @@ def overview(
         packages: dict[str, set[str]] = {}
 
         for base_pkg in base_packages:
+            repo = _repo_root(base_pkg)
             base_path = base_pkg.replace(".", "/")
 
             # resolve actual tree path (handles src/ layout)

--- a/api/main.py
+++ b/api/main.py
@@ -146,6 +146,13 @@ def _collect_classes_from_file(py_path: Path) -> list[str]:
     except Exception:
         return []
 
+
+def _parse_base_packages(raw: str) -> list[str]:
+    """Normalize a comma-separated list of base packages."""
+
+    return [chunk.strip() for chunk in raw.split(",") if chunk.strip()]
+
+
 class PackageClasses(BaseModel):
     package: str
     classes: list[str]
@@ -264,44 +271,56 @@ def overview(
     """
     try:
         repo = _repo_root()
-        base_path = base.replace(".", "/")
+        base_packages = _parse_base_packages(base)
+        if not base_packages:
+            raise HTTPException(status_code=400, detail="Provide at least one base package")
 
-        # resolve actual tree path (handles src/ layout)
-        resolved_tree = _resolve_base_tree(repo, branch, base_path)
+        packages: dict[str, set[str]] = {}
 
-        with tempfile.TemporaryDirectory() as td_str:
-            td = Path(td_str)
-            try:
-                _export_subtree(repo, branch, resolved_tree, td)
-            except subprocess.CalledProcessError as e:
-                raise HTTPException(status_code=404, detail=f"Cannot export {resolved_tree} at {branch}") from e
+        for base_pkg in base_packages:
+            base_path = base_pkg.replace(".", "/")
 
-            # the extracted folder root is td / <resolved_tree>
-            extract_root = td / resolved_tree
-            if not extract_root.exists():
-                raise HTTPException(status_code=404, detail=f"Extracted path missing: {resolved_tree}")
+            # resolve actual tree path (handles src/ layout)
+            resolved_tree = _resolve_base_tree(repo, branch, base_path)
 
-            items: list[PackageClasses] = []
-            for dirpath, dirnames, filenames in os.walk(extract_root):
-                pkg_dir = Path(dirpath)
-                if "__init__.py" not in filenames:
-                    continue
+            with tempfile.TemporaryDirectory() as td_str:
+                td = Path(td_str)
+                try:
+                    _export_subtree(repo, branch, resolved_tree, td)
+                except subprocess.CalledProcessError as e:
+                    raise HTTPException(status_code=404, detail=f"Cannot export {resolved_tree} at {branch}") from e
 
-                # rel path from the resolved tree root
-                rel_from_resolved = pkg_dir.relative_to(extract_root)
-                # Build full dotted package name: base + (optional tail)
-                tail = str(rel_from_resolved).replace("/", ".")
-                package_name = base if tail in ("", ".") else f"{base}.{tail}"
+                # the extracted folder root is td / <resolved_tree>
+                extract_root = td / resolved_tree
+                if not extract_root.exists():
+                    raise HTTPException(status_code=404, detail=f"Extracted path missing: {resolved_tree}")
 
-                cls_names: set[str] = set()
-                for f in filenames:
-                    if f.endswith(".py"):
-                        cls_names.update(_collect_classes_from_file(pkg_dir / f))
+                for dirpath, dirnames, filenames in os.walk(extract_root):
+                    pkg_dir = Path(dirpath)
+                    if "__init__.py" not in filenames:
+                        continue
 
-                items.append(PackageClasses(package=package_name, classes=sorted(cls_names)))
+                    # rel path from the resolved tree root
+                    rel_from_resolved = pkg_dir.relative_to(extract_root)
+                    # Build full dotted package name: base + (optional tail)
+                    tail = str(rel_from_resolved).replace("/", ".")
+                    package_name = base_pkg if tail in ("", ".") else f"{base_pkg}.{tail}"
 
-            items.sort(key=lambda x: x.package)
-            return OverviewOut(branch=branch, base=base, items=items)
+                    cls_names: set[str] = set()
+                    for f in filenames:
+                        if f.endswith(".py"):
+                            cls_names.update(_collect_classes_from_file(pkg_dir / f))
+
+                    if package_name not in packages:
+                        packages[package_name] = set()
+                    packages[package_name].update(cls_names)
+
+        items = [
+            PackageClasses(package=pkg, classes=sorted(classes))
+            for pkg, classes in sorted(packages.items())
+        ]
+
+        return OverviewOut(branch=branch, base=",".join(base_packages), items=items)
 
     except HTTPException:
         raise

--- a/api/routes_git.py
+++ b/api/routes_git.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
 from pathlib import Path
 from typing import Optional, List
-from .settings import DEFAULT_PACKAGE, DEFAULT_BASE_PACKAGE
+from .settings import DEFAULT_PACKAGE, DEFAULT_BASE_PACKAGE, repo_for_base_namespace
 from .git_utils import list_branches, materialize_worktree
 from .graph_runner import build_graph_in_subprocess
 from .diff import diff_graphs
@@ -72,10 +72,44 @@ def _parse_base_packages(raw: str) -> list[str]:
     return [chunk.strip() for chunk in raw.split(",") if chunk.strip()]
 
 
+def _bases_by_repo(base_packages: list[str]) -> dict[str, list[str]]:
+    mapping: dict[str, list[str]] = {}
+    for base in base_packages:
+        repo = repo_for_base_namespace(base)
+        mapping.setdefault(repo, []).append(base)
+    return mapping
+
+
+def _primary_repo(package: str | None, base_namespace: str | None) -> str:
+    if base_namespace:
+        bases = _parse_base_packages(base_namespace)
+        if bases:
+            return repo_for_base_namespace(bases[0])
+    if package:
+        # Use the top-level namespace to infer the owning repository
+        prefix = package.split(".")
+        for i in range(len(prefix), 0, -1):
+            candidate = ".".join(prefix[:i])
+            if candidate.startswith("nomad_measurements"):
+                return repo_for_base_namespace(candidate)
+        return repo_for_base_namespace(package)
+
+    defaults = _parse_base_packages(DEFAULT_BASE_PACKAGE)
+    if defaults:
+        return repo_for_base_namespace(defaults[0])
+    return repo_for_base_namespace(DEFAULT_BASE_PACKAGE)
+
+
 @router.get("/git/branches")
-def api_branches():
+def api_branches(base_package: str = Query(DEFAULT_BASE_PACKAGE)):
     try:
-        return {"branches": list_branches()}
+        bases = _parse_base_packages(base_package)
+        repos = _bases_by_repo(bases) if bases else {repo_for_base_namespace(DEFAULT_BASE_PACKAGE): []}
+
+        names: set[str] = set()
+        for repo_src in repos:
+            names.update(list_branches(repo_src))
+        return {"branches": sorted(names)}
     except Exception as e:
         raise HTTPException(500, str(e))
 
@@ -92,23 +126,25 @@ def api_packages(
     """
     try:
         # materialize_worktree returns (worktree_path, sha)
-        wt, sha = materialize_worktree(branch)
-
-        # Work out where Python packages live (usually <worktree>/src)
-        root = _python_root(wt)
-
         base_packages = _parse_base_packages(base_package)
         if not base_packages:
             raise HTTPException(400, "Provide at least one base package")
 
-        # Use the helper to list all modules under each base package
         packages: set[str] = set()
-        for base in base_packages:
-            packages.update(_list_modules_under(root, base))
+        repo_shas: list[dict] = []
+
+        for repo_src, bases in _bases_by_repo(base_packages).items():
+            wt, sha = materialize_worktree(branch, repo_src)
+            repo_shas.append({"source": repo_src, "sha": sha})
+
+            root = _python_root(wt)
+            for base in bases:
+                packages.update(_list_modules_under(root, base))
 
         return {
             "branch": branch,
-            "sha": sha,
+            "sha": repo_shas[0]["sha"] if repo_shas else None,
+            "repositories": repo_shas,
             "base_package": base_package,
             "base_packages": base_packages,
             "packages": sorted(packages),
@@ -118,11 +154,12 @@ def api_packages(
 
 
 @router.post("/graph")
-def api_graph(req: GraphRequest):
+def api_graph(req: GraphRequest, base_namespace: str | None = Query(None)):
     pkg = req.package or DEFAULT_PACKAGE
     try:
-        wt, sha = materialize_worktree(req.branch)
-        graph = build_graph_in_subprocess(wt, pkg, req.extractor)
+        repo_src = _primary_repo(pkg, base_namespace)
+        wt, sha = materialize_worktree(req.branch, repo_src)
+        graph = build_graph_in_subprocess(wt, pkg, req.extractor, base_namespace=base_namespace)
         return {"branch": req.branch, "sha": sha, "graph": graph}
     except Exception as e:
         raise HTTPException(500, str(e))
@@ -139,8 +176,9 @@ def api_diff(
 ):
     pkg = req.package or DEFAULT_PACKAGE
     try:
-        wtb, shab = materialize_worktree(req.base)
-        wth, shah = materialize_worktree(req.head)
+        repo_src = _primary_repo(pkg, base_namespace)
+        wtb, shab = materialize_worktree(req.base, repo_src)
+        wth, shah = materialize_worktree(req.head, repo_src)
 
         opts = {
             "root": root,

--- a/api/routes_git.py
+++ b/api/routes_git.py
@@ -66,6 +66,12 @@ def _list_modules_under(root: Path, base_package: str) -> List[str]:
     return sorted(modules)
 
 
+def _parse_base_packages(raw: str) -> list[str]:
+    """Normalize a comma-separated list of base packages."""
+
+    return [chunk.strip() for chunk in raw.split(",") if chunk.strip()]
+
+
 @router.get("/git/branches")
 def api_branches():
     try:
@@ -91,14 +97,21 @@ def api_packages(
         # Work out where Python packages live (usually <worktree>/src)
         root = _python_root(wt)
 
-        # Use the helper to list all modules under the base package
-        packages = _list_modules_under(root, base_package)
+        base_packages = _parse_base_packages(base_package)
+        if not base_packages:
+            raise HTTPException(400, "Provide at least one base package")
+
+        # Use the helper to list all modules under each base package
+        packages: set[str] = set()
+        for base in base_packages:
+            packages.update(_list_modules_under(root, base))
 
         return {
             "branch": branch,
             "sha": sha,
             "base_package": base_package,
-            "packages": packages,
+            "base_packages": base_packages,
+            "packages": sorted(packages),
         }
     except Exception as e:
         raise HTTPException(500, str(e))

--- a/api/settings.py
+++ b/api/settings.py
@@ -15,6 +15,9 @@ SCHEMA_REPO = (
     or str(Path.home() / "src/nomad-simulations")
 )
 
+# Optional: secondary repo for nomad-measurements
+MEASURE_REPO = os.getenv("NOMAD_MEASURE_REPO") or str(Path.home() / "src/nomad-measurements")
+
 
 def _repo_slug(src: str) -> str:
     """Return a filesystem-friendly slug for the bare mirror."""
@@ -52,3 +55,12 @@ DEFAULT_PACKAGE = os.getenv(
 )
 
 EXTRACTOR_ENTRY = os.getenv("SCHEMA_UML_EXTRACTOR", "extractor.graph_builder:build_graph")
+
+
+def repo_for_base_namespace(base_package: str) -> str:
+    """Return the repository source that owns the given base namespace."""
+
+    base = base_package.strip()
+    if base.startswith("nomad_measurements"):
+        return MEASURE_REPO
+    return SCHEMA_REPO

--- a/api/settings.py
+++ b/api/settings.py
@@ -36,7 +36,7 @@ REPO_SLUG = _repo_slug(SCHEMA_REPO)
 # Default base package/section can be overridden per request or via env vars
 DEFAULT_BASE_PACKAGE = os.getenv(
     "SCHEMA_UML_BASE_PACKAGE",
-    "nomad_simulations.schema_packages,nomad_measurements.schema_packages",
+    "nomad_simulations.schema_packages,nomad_measurements",
 )
 
 

--- a/api/settings.py
+++ b/api/settings.py
@@ -31,7 +31,24 @@ def _repo_slug(src: str) -> str:
 REPO_SLUG = _repo_slug(SCHEMA_REPO)
 
 # Default base package/section can be overridden per request or via env vars
-DEFAULT_BASE_PACKAGE = os.getenv("SCHEMA_UML_BASE_PACKAGE", "nomad_simulations.schema_packages")
-DEFAULT_PACKAGE = os.getenv("SCHEMA_UML_PACKAGE", f"{DEFAULT_BASE_PACKAGE}.model_method")
+DEFAULT_BASE_PACKAGE = os.getenv(
+    "SCHEMA_UML_BASE_PACKAGE",
+    "nomad_simulations.schema_packages,nomad_measurements.schema_packages",
+)
+
+
+def _primary_base_package(base_packages: str) -> str:
+    """Return the first non-empty base package from a comma-separated list."""
+
+    for chunk in base_packages.split(","):
+        candidate = chunk.strip()
+        if candidate:
+            return candidate
+    return "nomad_simulations.schema_packages"
+
+
+DEFAULT_PACKAGE = os.getenv(
+    "SCHEMA_UML_PACKAGE", f"{_primary_base_package(DEFAULT_BASE_PACKAGE)}.model_method"
+)
 
 EXTRACTOR_ENTRY = os.getenv("SCHEMA_UML_EXTRACTOR", "extractor.graph_builder:build_graph")

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -23,6 +23,10 @@ const DEFAULT_NAMESPACE =
   "nomad_simulations.schema_packages,nomad_measurements.schema_packages";
 const DEFAULT_ROOT = import.meta.env.VITE_DEFAULT_ROOT ?? "ModelMethod";
 const DEFAULT_BRANCH = import.meta.env.VITE_DEFAULT_BRANCH ?? "develop";
+const WORKSPACE_PRESETS = [
+  { label: "nomad-simulations", namespace: "nomad_simulations.schema_packages" },
+  { label: "nomad-measurements", namespace: "nomad_measurements.schema_packages" },
+];
 
 export default function App() {
   const [apiBase, setApiBase] = useState<string>(DEFAULT_API);
@@ -120,7 +124,7 @@ export default function App() {
   // fetch git branches
   const loadBranches = async () => {
     try {
-      const r = await api.get("/git/branches");
+      const r = await api.get("/git/branches", { params: { base_package: normalizedNamespace } });
       setBranches(r.data.branches || []);
     } catch (e) {
       // keep silent in UI; dropdown will just be empty
@@ -251,10 +255,14 @@ export default function App() {
 
   useEffect(() => {
     loadRoots();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
     loadBranches();
     loadPackages();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [normalizedNamespace]);
 
   const selectedClassName = selected?.kind === "class" ? selected.name : null;
   const addBlockedReason =
@@ -356,6 +364,18 @@ export default function App() {
                 </select>
               </div>
             )}
+          </div>
+          <div className="toggle-group" style={{ marginTop: 10 }}>
+            {WORKSPACE_PRESETS.map((ws) => (
+              <button
+                key={ws.namespace}
+                className={`toggle-chip ${normalizedNamespace === ws.namespace ? "active" : ""}`}
+                onClick={() => setNamespace(ws.namespace)}
+                title={`Set base namespace to ${ws.namespace}`}
+              >
+                {ws.label}
+              </button>
+            ))}
           </div>
         </CollapsibleSection>
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -20,12 +20,24 @@ const DEFAULT_API = "http://localhost:5179";
 const DEFAULT_PACKAGE = import.meta.env.VITE_DEFAULT_PACKAGE ?? "nomad_simulations.schema_packages.model_method";
 const DEFAULT_NAMESPACE =
   import.meta.env.VITE_DEFAULT_NAMESPACE ??
-  "nomad_simulations.schema_packages,nomad_measurements.schema_packages";
+  "nomad_simulations.schema_packages,nomad_measurements";
 const DEFAULT_ROOT = import.meta.env.VITE_DEFAULT_ROOT ?? "ModelMethod";
 const DEFAULT_BRANCH = import.meta.env.VITE_DEFAULT_BRANCH ?? "develop";
 const WORKSPACE_PRESETS = [
-  { label: "nomad-simulations", namespace: "nomad_simulations.schema_packages" },
-  { label: "nomad-measurements", namespace: "nomad_measurements.schema_packages" },
+  {
+    label: "nomad-simulations",
+    namespace: "nomad_simulations.schema_packages",
+    branch: "develop",
+    pkg: "nomad_simulations.schema_packages.model_method",
+    root: "ModelMethod",
+  },
+  {
+    label: "nomad-measurements",
+    namespace: "nomad_measurements",
+    branch: "main",
+    pkg: "nomad_measurements.general",
+    root: "InSituMeasurement",
+  },
 ];
 
 export default function App() {
@@ -74,6 +86,7 @@ export default function App() {
   // overview mode
   const [mode, setMode] = useState<"graph" | "overview">("graph");
   const [overviewBranch, setOverviewBranch] = useState<string>(DEFAULT_BRANCH);
+  const [packageBranch, setPackageBranch] = useState<string>(DEFAULT_BRANCH);
 
   const api = useMemo(() => axios.create({ baseURL: apiBase }), [apiBase]);
   const normalizedNamespace = useMemo(() => {
@@ -137,7 +150,7 @@ export default function App() {
     try {
       const r = await api.get("/git/packages", {
         params: {
-          branch: DEFAULT_BRANCH,
+          branch: packageBranch,
           base_package: normalizedNamespace,
         },
       });
@@ -262,7 +275,7 @@ export default function App() {
     loadBranches();
     loadPackages();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [normalizedNamespace]);
+  }, [normalizedNamespace, packageBranch]);
 
   const selectedClassName = selected?.kind === "class" ? selected.name : null;
   const addBlockedReason =
@@ -358,7 +371,7 @@ export default function App() {
                   value={overviewBranch}
                   onChange={(e) => setOverviewBranch(e.target.value)}
                 >
-                  {[DEFAULT_BRANCH, ...branches.filter((b) => b !== DEFAULT_BRANCH)].map((b) => (
+                  {[overviewBranch || DEFAULT_BRANCH, ...branches.filter((b) => b !== overviewBranch)].map((b) => (
                     <option key={b} value={b}>{b}</option>
                   ))}
                 </select>
@@ -370,7 +383,15 @@ export default function App() {
               <button
                 key={ws.namespace}
                 className={`toggle-chip ${normalizedNamespace === ws.namespace ? "active" : ""}`}
-                onClick={() => setNamespace(ws.namespace)}
+                onClick={() => {
+                  setNamespace(ws.namespace);
+                  if (ws.branch) {
+                    setOverviewBranch(ws.branch);
+                    setPackageBranch(ws.branch);
+                  }
+                  if (ws.pkg) setPkg(ws.pkg);
+                  if (ws.root) setRoot(ws.root);
+                }}
                 title={`Set base namespace to ${ws.namespace}`}
               >
                 {ws.label}
@@ -403,7 +424,7 @@ export default function App() {
 
             {availablePkgs.length > 0 && (
               <div>
-                <label className="label">Choose from {DEFAULT_BRANCH}</label>
+                <label className="label">Choose from {packageBranch}</label>
                 <select
                   className="select"
                   value={availablePkgs.includes(pkg) ? pkg : ""}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -18,7 +18,9 @@ type ApiGraph = {
 
 const DEFAULT_API = "http://localhost:5179";
 const DEFAULT_PACKAGE = import.meta.env.VITE_DEFAULT_PACKAGE ?? "nomad_simulations.schema_packages.model_method";
-const DEFAULT_NAMESPACE = import.meta.env.VITE_DEFAULT_NAMESPACE ?? "nomad_simulations.schema_packages";
+const DEFAULT_NAMESPACE =
+  import.meta.env.VITE_DEFAULT_NAMESPACE ??
+  "nomad_simulations.schema_packages,nomad_measurements.schema_packages";
 const DEFAULT_ROOT = import.meta.env.VITE_DEFAULT_ROOT ?? "ModelMethod";
 const DEFAULT_BRANCH = import.meta.env.VITE_DEFAULT_BRANCH ?? "develop";
 
@@ -70,6 +72,10 @@ export default function App() {
   const [overviewBranch, setOverviewBranch] = useState<string>(DEFAULT_BRANCH);
 
   const api = useMemo(() => axios.create({ baseURL: apiBase }), [apiBase]);
+  const normalizedNamespace = useMemo(() => {
+    const parts = namespace.split(",").map((p) => p.trim()).filter(Boolean);
+    return parts.length > 0 ? parts.join(",") : DEFAULT_NAMESPACE;
+  }, [namespace]);
 
   // roots for selected package
   const loadRoots = async () => {
@@ -99,7 +105,7 @@ export default function App() {
           include_quantities: includeQuantities,
           include_subsections: includeSubsections,
           allow_cross_module: crossModules,
-          base_namespace: namespace || undefined,
+          base_namespace: normalizedNamespace || undefined,
         },
       });
       setGraph(r.data);
@@ -128,7 +134,7 @@ export default function App() {
       const r = await api.get("/git/packages", {
         params: {
           branch: DEFAULT_BRANCH,
-          base_package: namespace || DEFAULT_NAMESPACE,
+          base_package: normalizedNamespace,
         },
       });
       const list: string[] = r.data.packages || [];
@@ -165,7 +171,7 @@ export default function App() {
             include_quantities: includeQuantities,
             include_subsections: includeSubsections,
             allow_cross_module: crossModules,
-            base_namespace: namespace || undefined,
+            base_namespace: normalizedNamespace || undefined,
           },
         }
       );
@@ -226,13 +232,13 @@ export default function App() {
         },
         {
           params: {
-            root,
-            include_subsections: includeSubsections,
-            allow_cross_module: crossModules,
-            base_namespace: namespace || undefined,
-          },
-        }
-      );
+          root,
+          include_subsections: includeSubsections,
+          allow_cross_module: crossModules,
+          base_namespace: normalizedNamespace || undefined,
+        },
+      }
+    );
       const updated = r.data as ApiGraph;
       setGraph(updated);
       refreshSelectionQuantities(updated);
@@ -452,7 +458,7 @@ export default function App() {
           </div>
 
           <div style={{ marginTop: 10 }}>
-            <label className="label">Base namespace (optional)</label>
+            <label className="label">Base namespace (supports comma-separated)</label>
             <input
               className="input"
               value={namespace}
@@ -563,7 +569,7 @@ export default function App() {
         {/* Left: graph area */}
         <div style={{ minWidth: 0 }}>
           {mode === "overview" ? (
-            <OverviewGrid apiBase={apiBase} branch={overviewBranch} base={namespace || DEFAULT_NAMESPACE} />
+            <OverviewGrid apiBase={apiBase} branch={overviewBranch} base={normalizedNamespace} />
           ) : diffData ? (
             <>
               <div className="workspace-toolbar">

--- a/web/src/components/OverviewGrid.tsx
+++ b/web/src/components/OverviewGrid.tsx
@@ -3,7 +3,9 @@ import { useEffect, useMemo, useState } from "react";
 type OverviewItem = { package: string; classes: string[] };
 type OverviewResp = { branch: string; base: string; items: OverviewItem[] };
 
-const DEFAULT_OVERVIEW_BASE = import.meta.env.VITE_DEFAULT_NAMESPACE ?? "nomad_simulations.schema_packages";
+const DEFAULT_OVERVIEW_BASE =
+  import.meta.env.VITE_DEFAULT_NAMESPACE ??
+  "nomad_simulations.schema_packages,nomad_measurements.schema_packages";
 
 export default function OverviewGrid({
   apiBase,

--- a/web/src/components/OverviewGrid.tsx
+++ b/web/src/components/OverviewGrid.tsx
@@ -5,7 +5,7 @@ type OverviewResp = { branch: string; base: string; items: OverviewItem[] };
 
 const DEFAULT_OVERVIEW_BASE =
   import.meta.env.VITE_DEFAULT_NAMESPACE ??
-  "nomad_simulations.schema_packages,nomad_measurements.schema_packages";
+  "nomad_simulations.schema_packages,nomad_measurements";
 
 export default function OverviewGrid({
   apiBase,

--- a/web/src/components/OverviewList.tsx
+++ b/web/src/components/OverviewList.tsx
@@ -3,7 +3,9 @@ import { useEffect, useState } from "react";
 type OverviewItem = { package: string; classes: string[] };
 type OverviewResp = { branch: string; base: string; items: OverviewItem[] };
 
-const DEFAULT_OVERVIEW_BASE = import.meta.env.VITE_DEFAULT_NAMESPACE ?? "nomad_simulations.schema_packages";
+const DEFAULT_OVERVIEW_BASE =
+  import.meta.env.VITE_DEFAULT_NAMESPACE ??
+  "nomad_simulations.schema_packages,nomad_measurements.schema_packages";
 
 export default function OverviewList({
   apiBase,

--- a/web/src/components/OverviewList.tsx
+++ b/web/src/components/OverviewList.tsx
@@ -5,7 +5,7 @@ type OverviewResp = { branch: string; base: string; items: OverviewItem[] };
 
 const DEFAULT_OVERVIEW_BASE =
   import.meta.env.VITE_DEFAULT_NAMESPACE ??
-  "nomad_simulations.schema_packages,nomad_measurements.schema_packages";
+  "nomad_simulations.schema_packages,nomad_measurements";
 
 export default function OverviewList({
   apiBase,


### PR DESCRIPTION
## Summary
- allow comma-separated base package inputs for package listing and overview APIs and merge results
- default configuration includes both simulations and measurements namespaces on the server and client
- normalize base namespace handling in the UI and clarify multi-namespace support

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ab07282e48320820c375263a80bac)