### PR TITLE
Enable editing and removing quantities in editable mode

### DIFF
--- a/api/routes_git.py
+++ b/api/routes_git.py
@@ -107,9 +107,18 @@ def api_branches(base_package: str = Query(DEFAULT_BASE_PACKAGE)):
         repos = _bases_by_repo(bases) if bases else {repo_for_base_namespace(DEFAULT_BASE_PACKAGE): []}
 
         names: set[str] = set()
+        errors: list[str] = []
+
         for repo_src in repos:
-            names.update(list_branches(repo_src))
-        return {"branches": sorted(names)}
+            try:
+                names.update(list_branches(repo_src))
+            except Exception as e:
+                errors.append(f"{repo_src}: {e}")
+
+        if not names and errors:
+            raise HTTPException(500, "; ".join(errors))
+
+        return {"branches": sorted(names), "errors": errors or None}
     except Exception as e:
         raise HTTPException(500, str(e))
 
@@ -132,14 +141,23 @@ def api_packages(
 
         packages: set[str] = set()
         repo_shas: list[dict] = []
+        errors: list[str] = []
 
         for repo_src, bases in _bases_by_repo(base_packages).items():
-            wt, sha = materialize_worktree(branch, repo_src)
+            try:
+                wt, sha = materialize_worktree(branch, repo_src)
+            except Exception as e:
+                errors.append(f"{repo_src}: {e}")
+                continue
+
             repo_shas.append({"source": repo_src, "sha": sha})
 
             root = _python_root(wt)
             for base in bases:
                 packages.update(_list_modules_under(root, base))
+
+        if not packages and errors:
+            raise HTTPException(500, "; ".join(errors))
 
         return {
             "branch": branch,
@@ -148,6 +166,7 @@ def api_packages(
             "base_package": base_package,
             "base_packages": base_packages,
             "packages": sorted(packages),
+            "errors": errors or None,
         }
     except Exception as e:
         raise HTTPException(500, str(e))

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -512,7 +512,7 @@ export default function App() {
             </div>
 
             <div>
-              <label className="label">Package (module)</label>
+              <label className="label">Package</label>
               <input
                 className="input"
                 value={pkg}
@@ -521,23 +521,41 @@ export default function App() {
               />
             </div>
 
-            {availablePkgs.length > 0 && (
-              <div>
-                <label className="label">Choose from {packageBranch}</label>
+            <div className="row" style={{ gap: 10, alignItems: "flex-end" }}>
+              <div style={{ flex: 1 }}>
+                <label className="label">Choose from branch</label>
                 <select
                   className="select"
-                  value={availablePkgs.includes(pkg) ? pkg : ""}
-                  onChange={(e) => setPkg(e.target.value)}
+                  value={packageBranch}
+                  onChange={(e) => setPackageBranch(e.target.value)}
                 >
-                  <option value="">Custom module...</option>
-                  {availablePkgs.map((name) => (
-                    <option key={name} value={name}>
-                      {name}
+                  {[packageBranch || DEFAULT_BRANCH, ...branches.filter((b) => b !== packageBranch)].map((b) => (
+                    <option key={b} value={b}>
+                      {b}
                     </option>
                   ))}
                 </select>
               </div>
-            )}
+              <button className="btn secondary" onClick={loadPackages} style={{ whiteSpace: "nowrap" }}>
+                Refresh packages
+              </button>
+            </div>
+
+            <div>
+              <label className="label">Choose from {packageBranch || DEFAULT_BRANCH}</label>
+              <select
+                className="select"
+                value={availablePkgs.includes(pkg) ? pkg : ""}
+                onChange={(e) => setPkg(e.target.value)}
+              >
+                <option value="">Custom package...</option>
+                {availablePkgs.map((name) => (
+                  <option key={name} value={name}>
+                    {name}
+                  </option>
+                ))}
+              </select>
+            </div>
 
             <div className="row" style={{ justifyContent: "space-between" }}>
               <div>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import axios from "axios";
 import GraphView, { type GraphExportHandle } from "./GraphView";
 import DocPanel from "./components/DocPanel";
 import OverviewGrid from "./components/OverviewGrid";
 import UnderTheHoodPanel from './components/UnderTheHoodPanel';
 import AddQuantityForm from "./components/AddQuantityForm";
+import type { QuantityFormData } from "./components/quantityShared";
 import CollapsibleSection from "./components/CollapsibleSection";
 import { useSelection } from "./store/selection";
 import { jsPDF } from "jspdf";
@@ -77,10 +78,13 @@ export default function App() {
   const [editableMode, setEditableMode] = useState<boolean>(false);
   const [addLoading, setAddLoading] = useState<boolean>(false);
   const [addErr, setAddErr] = useState<string | null>(null);
+  const [quantityActionErr, setQuantityActionErr] = useState<string | null>(null);
 
   const [exportHandle, setExportHandle] = useState<GraphExportHandle | null>(null);
 
   const { selected, setSelected } = useSelection();
+
+  const clearQuantityActionError = useCallback(() => setQuantityActionErr(null), []);
 
   // overview mode
   const [mode, setMode] = useState<"graph" | "overview">("graph");
@@ -110,6 +114,7 @@ export default function App() {
   // build single-branch graph (resets diff view)
   const loadGraph = async () => {
     setErr(null);
+    setQuantityActionErr(null);
     setLoading(true);
     setDiffData(null);
     setExportHandle(null);
@@ -170,6 +175,7 @@ export default function App() {
   const compareBranches = async () => {
     if (!baseBranch || !headBranch) return;
     setErr(null);
+    setQuantityActionErr(null);
     setDiffLoading(true);
     setGraph(null); // switch to diff mode
     setExportHandle(null);
@@ -248,16 +254,17 @@ export default function App() {
         },
         {
           params: {
-          root,
-          include_subsections: includeSubsections,
-          allow_cross_module: crossModules,
-          base_namespace: normalizedNamespace || undefined,
-        },
-      }
-    );
+            root,
+            include_subsections: includeSubsections,
+            allow_cross_module: crossModules,
+            base_namespace: normalizedNamespace || undefined,
+          },
+        }
+      );
       const updated = r.data as ApiGraph;
       setGraph(updated);
       refreshSelectionQuantities(updated);
+      setQuantityActionErr(null);
     } catch (e: any) {
       setAddErr(e?.response?.data?.detail || String(e));
     } finally {
@@ -279,14 +286,107 @@ export default function App() {
   const selectedClassName = selected?.kind === "class" ? selected.name : null;
   const addBlockedReason =
     mode !== "graph"
-      ? "Switch to diagram view to add quantities"
+      ? "Switch to diagram view to modify quantities"
       : diffData
-        ? "Exit branch comparison to add quantities"
+        ? "Exit branch comparison to modify quantities"
         : !graph
-          ? "Build a graph first to add quantities"
+          ? "Build a graph first to modify quantities"
           : null;
 
   const currentGraph = diffData ? diffData.head?.graph ?? null : graph;
+
+  const ensureEditableReady = () => {
+    if (addBlockedReason) {
+      setQuantityActionErr(addBlockedReason);
+      return null;
+    }
+    if (!editableMode) {
+      setQuantityActionErr("Enable editable mode to edit or remove quantities.");
+      return null;
+    }
+    if (!graph) {
+      setQuantityActionErr("Build a graph first to modify quantities.");
+      return null;
+    }
+    return graph;
+  };
+
+  const editQuantity = (quantityId: string, updates: QuantityFormData) => {
+    const current = ensureEditableReady();
+    if (!current) return;
+
+    const target = current.nodes.find((n) => n.id === quantityId && n.kind === "quantity");
+    if (!target) {
+      setQuantityActionErr("Quantity not found in current graph.");
+      return;
+    }
+    if (!target.owner) {
+      setQuantityActionErr("Cannot edit a quantity without an owner.");
+      return;
+    }
+
+    const trimmedName = updates.quantityName.trim();
+    if (!trimmedName) {
+      setQuantityActionErr("Quantity name cannot be empty.");
+      return;
+    }
+
+    const newId = `${target.owner}.${trimmedName}`;
+    const conflict = current.nodes.some(
+      (n) => n.kind === "quantity" && n.owner === target.owner && n.id !== quantityId && (n.id === newId || n.label === trimmedName)
+    );
+    if (conflict) {
+      setQuantityActionErr("A quantity with that name already exists on this class.");
+      return;
+    }
+
+    const nextNodes = current.nodes.map((n) => {
+      if (n.id !== quantityId) return n;
+      return { ...n, id: newId, label: trimmedName, doc: updates.docstring || null, dtype: updates.dtype };
+    });
+
+    const nextEdges = current.edges.map((e) => {
+      if (e.source === quantityId) return { ...e, source: newId };
+      if (e.target === quantityId) return { ...e, target: newId };
+      return e;
+    });
+
+    const nextGraph = { ...current, nodes: nextNodes, edges: nextEdges };
+    setGraph(nextGraph);
+    refreshSelectionQuantities(nextGraph);
+    setQuantityActionErr(null);
+
+    if (selected?.kind === "quantity" && selected.id === quantityId) {
+      setSelected({ ...selected, id: newId, name: trimmedName, doc: updates.docstring, dtype: updates.dtype, owner: selected.owner });
+    }
+  };
+
+  const removeQuantity = (quantityId: string) => {
+    const current = ensureEditableReady();
+    if (!current) return;
+
+    const target = current.nodes.find((n) => n.id === quantityId && n.kind === "quantity");
+    if (!target) {
+      setQuantityActionErr("Quantity not found in current graph.");
+      return;
+    }
+    if (!target.owner) {
+      setQuantityActionErr("Cannot remove a quantity without an owner.");
+      return;
+    }
+
+    const nextNodes = current.nodes.filter((n) => n.id !== quantityId);
+    const nextEdges = current.edges.filter((e) => e.source !== quantityId && e.target !== quantityId);
+    const nextGraph = { ...current, nodes: nextNodes, edges: nextEdges };
+
+    setGraph(nextGraph);
+    refreshSelectionQuantities(nextGraph);
+    setQuantityActionErr(null);
+
+    if (selected?.kind === "quantity" && selected.id === quantityId) {
+      setSelected(null);
+    }
+  };
 
   const exportJson = () => {
     if (!currentGraph) return;
@@ -534,6 +634,7 @@ export default function App() {
                 onChange={(e) => {
                   setEditableMode(e.target.checked);
                   setAddErr(null);
+                  setQuantityActionErr(null);
                 }}
               />
               Editable mode
@@ -657,7 +758,14 @@ export default function App() {
             }}
           >
             <CollapsibleSection title="Documentation" hint="Inspect the selected class" className="panel">
-              <DocPanel />
+              <DocPanel
+                editableMode={editableMode}
+                onEditQuantity={editQuantity}
+                onRemoveQuantity={removeQuantity}
+                blockedReason={addBlockedReason}
+                actionError={quantityActionErr}
+                clearActionError={clearQuantityActionError}
+              />
             </CollapsibleSection>
           </div>
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -639,33 +639,6 @@ export default function App() {
           <UnderTheHoodPanel apiBase={apiBase} />
         </CollapsibleSection>
 
-        <CollapsibleSection title="Editable mode" hint="Prototype new quantities">
-          <div className="row" style={{ marginBottom: 6 }}>
-            <label style={{ display: "flex", gap: 6, alignItems: "center" }}>
-              <input
-                type="checkbox"
-                checked={editableMode}
-                onChange={(e) => {
-                  setEditableMode(e.target.checked);
-                  setAddErr(null);
-                  setQuantityActionErr(null);
-                }}
-              />
-              Editable mode
-            </label>
-            {addBlockedReason && <span className="small">{addBlockedReason}</span>}
-          </div>
-
-          <AddQuantityForm
-            enabled={editableMode && !addBlockedReason}
-            blockedReason={addBlockedReason}
-            targetClass={selectedClassName}
-            onSubmit={addCustomQuantity}
-            submitting={addLoading}
-            error={addErr}
-          />
-        </CollapsibleSection>
-
         <CollapsibleSection title="Compare branches" hint="Diff diagrams across git">
           <div className="action-stack">
             <div>
@@ -751,7 +724,7 @@ export default function App() {
           )}
         </div>
 
-        {/* Right: DocPanel (top) + Under-the-hood (bottom) */}
+        {/* Right: Documentation + quantity editing */}
         <div
           style={{
             minWidth: 0,
@@ -763,10 +736,10 @@ export default function App() {
             gap: "10px"
           }}
         >
-          {/* TOP PANEL — about 60% */}
+          {/* TOP PANEL — about half */}
           <div
             style={{
-              flex: 6,
+              flex: 5,
               minHeight: 0,
               overflowY: "auto"
             }}
@@ -781,23 +754,61 @@ export default function App() {
             </CollapsibleSection>
           </div>
 
-          {/* BOTTOM PANEL — about 40% */}
+          {/* BOTTOM PANEL — editable mode controls */}
           <div
             style={{
-              flex: 4,
+              flex: 5,
               minHeight: 0,
               overflowY: "auto"
             }}
           >
-            <CollapsibleSection title="Edit quantity" hint="Modify or remove a selected quantity" className="panel">
-              <QuantityEditPanel
-                editableMode={editableMode}
-                blockedReason={addBlockedReason}
-                actionError={quantityActionErr}
-                clearActionError={clearQuantityActionError}
-                onEditQuantity={editQuantity}
-                onRemoveQuantity={removeQuantity}
-              />
+            <CollapsibleSection
+              title="Editable mode"
+              hint="Enable editing, add quantities, or modify existing ones"
+              className="panel"
+            >
+              <div className="action-stack" style={{ gap: 14 }}>
+                <div className="row" style={{ alignItems: "center", gap: 10 }}>
+                  <label style={{ display: "flex", gap: 6, alignItems: "center" }}>
+                    <input
+                      type="checkbox"
+                      checked={editableMode}
+                      onChange={(e) => {
+                        setEditableMode(e.target.checked);
+                        setAddErr(null);
+                        setQuantityActionErr(null);
+                      }}
+                    />
+                    Editable mode
+                  </label>
+                  {addBlockedReason && <span className="small">{addBlockedReason}</span>}
+                </div>
+
+                <AddQuantityForm
+                  enabled={editableMode && !addBlockedReason}
+                  blockedReason={addBlockedReason}
+                  targetClass={selectedClassName}
+                  onSubmit={addCustomQuantity}
+                  submitting={addLoading}
+                  error={addErr}
+                />
+
+                <div
+                  style={{
+                    borderTop: "1px solid var(--panel-border)",
+                    margin: "4px 0",
+                  }}
+                />
+
+                <QuantityEditPanel
+                  editableMode={editableMode}
+                  blockedReason={addBlockedReason}
+                  actionError={quantityActionErr}
+                  clearActionError={clearQuantityActionError}
+                  onEditQuantity={editQuantity}
+                  onRemoveQuantity={removeQuantity}
+                />
+              </div>
             </CollapsibleSection>
           </div>
         </div>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -499,7 +499,7 @@ export default function App() {
           </div>
         </CollapsibleSection>
 
-        <CollapsibleSection title="API & package" hint="Connect to a backend">
+        <CollapsibleSection title="API, package & filters" hint="Connect to a backend and fine-tune the graph">
           <div className="action-stack">
             <div>
               <label className="label">API base</label>
@@ -558,71 +558,59 @@ export default function App() {
                 <div className="small">{roots.length ? `${roots.length} sections` : ""}</div>
               </div>
             </div>
-          </div>
-        </CollapsibleSection>
 
-        <CollapsibleSection title="Diagram filters" hint="Fine-tune the graph">
-          <div className="control-grid">
-            <label style={{ display: "flex", gap: 6, alignItems: "center" }}>
-              <input
-                type="checkbox"
-                checked={includeQuantities}
-                onChange={(e) => setIncludeQuantities(e.target.checked)}
-              />
-              Quantities
-            </label>
-            <label style={{ display: "flex", gap: 6, alignItems: "center" }}>
-              <input
-                type="checkbox"
-                checked={includeSubsections}
-                onChange={(e) => setIncludeSubsections(e.target.checked)}
-              />
-              Subsections
-            </label>
-            <label style={{ display: "flex", gap: 6, alignItems: "center" }}>
-              <input
-                type="checkbox"
-                checked={crossModules}
-                onChange={(e) => setCrossModules(e.target.checked)}
-              />
-              Cross-modules
-            </label>
-          </div>
+            <div className="control-grid" style={{ marginTop: 4 }}>
+              <label style={{ display: "flex", gap: 6, alignItems: "center" }}>
+                <input
+                  type="checkbox"
+                  checked={includeQuantities}
+                  onChange={(e) => setIncludeQuantities(e.target.checked)}
+                />
+                Quantities
+              </label>
+              <label style={{ display: "flex", gap: 6, alignItems: "center" }}>
+                <input
+                  type="checkbox"
+                  checked={includeSubsections}
+                  onChange={(e) => setIncludeSubsections(e.target.checked)}
+                />
+                Subsections
+              </label>
+              <label style={{ display: "flex", gap: 6, alignItems: "center" }}>
+                <input
+                  type="checkbox"
+                  checked={crossModules}
+                  onChange={(e) => setCrossModules(e.target.checked)}
+                />
+                Cross-modules
+              </label>
+            </div>
 
-          <div style={{ marginTop: 10 }}>
-            <label className="label">Base namespace (supports comma-separated)</label>
-            <input
-              className="input"
-              value={namespace}
-              onChange={(e) => setNamespace(e.target.value)}
-              placeholder={DEFAULT_NAMESPACE}
-            />
-          </div>
+            <div className="row" style={{ marginTop: 14, justifyContent: "space-between", gap: 10 }}>
+              <button className="btn" onClick={loadGraph}>
+                Build graph
+              </button>
+              {currentGraph ? (
+                <div className="row" style={{ flex: 1, justifyContent: "flex-end" }}>
+                  <button className="btn secondary" onClick={exportJson}>
+                    Export JSON
+                  </button>
+                  <button
+                    className="btn secondary"
+                    onClick={exportPdf}
+                    disabled={!exportHandle}
+                    title={exportHandle ? "Download current diagram as PDF" : "Build a graph first"}
+                  >
+                    Export PDF
+                  </button>
+                </div>
+              ) : null}
+            </div>
 
-          <div className="row" style={{ marginTop: 14, justifyContent: "space-between", gap: 10 }}>
-            <button className="btn" onClick={loadGraph}>
-              Build graph
-            </button>
-            {currentGraph ? (
-              <div className="row" style={{ flex: 1, justifyContent: "flex-end" }}>
-                <button className="btn secondary" onClick={exportJson}>
-                  Export JSON
-                </button>
-                <button
-                  className="btn secondary"
-                  onClick={exportPdf}
-                  disabled={!exportHandle}
-                  title={exportHandle ? "Download current diagram as PDF" : "Build a graph first"}
-                >
-                  Export PDF
-                </button>
-              </div>
+            {err ? (
+              <p style={{ color: "#fca5a5", marginTop: 10, whiteSpace: "pre-wrap" }}>{err}</p>
             ) : null}
           </div>
-
-          {err ? (
-            <p style={{ color: "#fca5a5", marginTop: 10, whiteSpace: "pre-wrap" }}>{err}</p>
-          ) : null}
         </CollapsibleSection>
 
         <CollapsibleSection title="Editable mode" hint="Prototype new quantities">

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,7 +5,6 @@ import DocPanel from "./components/DocPanel";
 import OverviewGrid from "./components/OverviewGrid";
 import UnderTheHoodPanel from "./components/UnderTheHoodPanel";
 import AddQuantityForm from "./components/AddQuantityForm";
-import QuantityEditPanel from "./components/QuantityEditPanel";
 import type { QuantityFormData } from "./components/quantityShared";
 import CollapsibleSection from "./components/CollapsibleSection";
 import { useSelection } from "./store/selection";
@@ -744,11 +743,13 @@ export default function App() {
               overflowY: "auto"
             }}
           >
-            <CollapsibleSection title="Documentation" hint="Inspect the selected class" className="panel">
+            <CollapsibleSection title="Documentation" hint="Browse docs and edit quantities" className="panel">
               <DocPanel
                 editableMode={editableMode}
                 onRemoveQuantity={removeQuantity}
+                onEditQuantity={editQuantity}
                 blockedReason={addBlockedReason}
+                actionError={quantityActionErr}
                 clearActionError={clearQuantityActionError}
               />
             </CollapsibleSection>
@@ -764,7 +765,7 @@ export default function App() {
           >
             <CollapsibleSection
               title="Editable mode"
-              hint="Enable editing, add quantities, or modify existing ones"
+              hint="Enable editing and add new quantities"
               className="panel"
             >
               <div className="action-stack" style={{ gap: 14 }}>
@@ -791,22 +792,6 @@ export default function App() {
                   onSubmit={addCustomQuantity}
                   submitting={addLoading}
                   error={addErr}
-                />
-
-                <div
-                  style={{
-                    borderTop: "1px solid var(--panel-border)",
-                    margin: "4px 0",
-                  }}
-                />
-
-                <QuantityEditPanel
-                  editableMode={editableMode}
-                  blockedReason={addBlockedReason}
-                  actionError={quantityActionErr}
-                  clearActionError={clearQuantityActionError}
-                  onEditQuantity={editQuantity}
-                  onRemoveQuantity={removeQuantity}
                 />
               </div>
             </CollapsibleSection>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -216,7 +216,7 @@ export default function App() {
       .map((n: any) => ({
         id: n.id,
         name: n.label,
-        dtype: n.dtype ?? undefined,
+        dtype: n.dtype ?? n.data_type ?? n.type ?? undefined,
         shape: n.shape ?? undefined,
         card: n.card ?? undefined,
         doc: n.doc ?? undefined,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,8 +3,9 @@ import axios from "axios";
 import GraphView, { type GraphExportHandle } from "./GraphView";
 import DocPanel from "./components/DocPanel";
 import OverviewGrid from "./components/OverviewGrid";
-import UnderTheHoodPanel from './components/UnderTheHoodPanel';
+import UnderTheHoodPanel from "./components/UnderTheHoodPanel";
 import AddQuantityForm from "./components/AddQuantityForm";
+import QuantityEditPanel from "./components/QuantityEditPanel";
 import type { QuantityFormData } from "./components/quantityShared";
 import CollapsibleSection from "./components/CollapsibleSection";
 import { useSelection } from "./store/selection";
@@ -634,6 +635,10 @@ export default function App() {
           </div>
         </CollapsibleSection>
 
+        <CollapsibleSection title="Under the hood" hint="Raw schema structure">
+          <UnderTheHoodPanel apiBase={apiBase} />
+        </CollapsibleSection>
+
         <CollapsibleSection title="Editable mode" hint="Prototype new quantities">
           <div className="row" style={{ marginBottom: 6 }}>
             <label style={{ display: "flex", gap: 6, alignItems: "center" }}>
@@ -769,10 +774,8 @@ export default function App() {
             <CollapsibleSection title="Documentation" hint="Inspect the selected class" className="panel">
               <DocPanel
                 editableMode={editableMode}
-                onEditQuantity={editQuantity}
                 onRemoveQuantity={removeQuantity}
                 blockedReason={addBlockedReason}
-                actionError={quantityActionErr}
                 clearActionError={clearQuantityActionError}
               />
             </CollapsibleSection>
@@ -786,8 +789,15 @@ export default function App() {
               overflowY: "auto"
             }}
           >
-            <CollapsibleSection title="Under the hood" hint="Raw schema structure" className="panel">
-              <UnderTheHoodPanel apiBase={apiBase} />
+            <CollapsibleSection title="Edit quantity" hint="Modify or remove a selected quantity" className="panel">
+              <QuantityEditPanel
+                editableMode={editableMode}
+                blockedReason={addBlockedReason}
+                actionError={quantityActionErr}
+                clearActionError={clearQuantityActionError}
+                onEditQuantity={editQuantity}
+                onRemoveQuantity={removeQuantity}
+              />
             </CollapsibleSection>
           </div>
         </div>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -151,6 +151,7 @@ export default function App() {
 
   // fetch available schema packages from develop branch
   const loadPackages = async () => {
+    setErr(null);
     try {
       const r = await api.get("/git/packages", {
         params: {
@@ -168,6 +169,8 @@ export default function App() {
     } catch (e) {
       // silent failure is fine; user can still type manually
       console.error("Failed to load packages", e);
+      // surface the error so users know why the dropdown is empty
+      setErr((e as any)?.response?.data?.detail || String(e));
     }
   };
 
@@ -275,7 +278,7 @@ export default function App() {
   useEffect(() => {
     loadRoots();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [pkg, apiBase]);
 
   useEffect(() => {
     loadBranches();

--- a/web/src/GraphView.tsx
+++ b/web/src/GraphView.tsx
@@ -115,7 +115,7 @@ export default function GraphView({ nodes, edges, diff, onReady }: Props) {
       const list = attrs.get(q.owner) ?? [];
       list.push({
         name: q.label,
-        dtype: q.dtype ?? undefined,
+        dtype: q.dtype ?? q.data_type ?? q.type ?? undefined,
         shape: q.shape ?? undefined,
         card: q.card ?? undefined
       });
@@ -126,7 +126,7 @@ export default function GraphView({ nodes, edges, diff, onReady }: Props) {
       metaList.push({
         id: q.id,
         name: q.label,
-        dtype: q.dtype ?? undefined,
+        dtype: q.dtype ?? q.data_type ?? q.type ?? undefined,
         shape: q.shape ?? undefined,
         card: q.card ?? undefined,
         doc: q.doc ?? undefined,

--- a/web/src/components/AddQuantityForm.tsx
+++ b/web/src/components/AddQuantityForm.tsx
@@ -1,21 +1,14 @@
 import React, { useMemo, useState } from "react";
-
-type FormData = {
-  quantityName: string;
-  dtype: string;
-  docstring: string;
-};
+import { SUPPORTED_DTYPES, type QuantityFormData } from "./quantityShared";
 
 type Props = {
   enabled: boolean;
   targetClass: string | null;
-  onSubmit: (data: FormData) => Promise<void>;
+  onSubmit: (data: QuantityFormData) => Promise<void>;
   submitting: boolean;
   error: string | null;
   blockedReason?: string | null;
 };
-
-const SUPPORTED_DTYPES = ["bool", "datetime", "float", "int", "str"];
 
 export default function AddQuantityForm({ enabled, targetClass, onSubmit, submitting, error, blockedReason }: Props) {
   const [quantityName, setQuantityName] = useState("");

--- a/web/src/components/DocPanel.tsx
+++ b/web/src/components/DocPanel.tsx
@@ -16,9 +16,17 @@ function QtyRow({ q, onClick, onEdit, onRemove, editableMode, disabled }: { q: Q
   if (q.dtype) meta.push(q.dtype);
   if (q.shape && q.shape !== "[]") meta.push(q.shape);
   if (q.card) meta.push(`[${q.card}]`);
+  const handleClick = () => {
+    if (editableMode && !disabled) {
+      onEdit();
+      onClick();
+      return;
+    }
+    onClick();
+  };
   return (
     <div className="qty-row" style={{ gap: 8 }}>
-      <button className="qty-row" onClick={onClick} style={{ flex: 1 }}>
+      <button className="qty-row" type="button" onClick={handleClick} style={{ flex: 1 }}>
         <div style={{ flex: 1 }} className="qty-mono">
           <div style={{ fontSize: 13 }}>{q.name}</div>
           <div style={{ fontSize: 11, opacity: 0.7 }}>{meta.join("  ")}</div>
@@ -28,10 +36,10 @@ function QtyRow({ q, onClick, onEdit, onRemove, editableMode, disabled }: { q: Q
 
       {editableMode && (
         <div className="row" style={{ gap: 6 }}>
-          <button className="btn secondary" style={{ padding: "6px 10px" }} onClick={onEdit} disabled={disabled}>
+          <button className="btn secondary" type="button" style={{ padding: "6px 10px" }} onClick={onEdit} disabled={disabled}>
             Edit
           </button>
-          <button className="btn secondary" style={{ padding: "6px 10px" }} onClick={onRemove} disabled={disabled}>
+          <button className="btn secondary" type="button" style={{ padding: "6px 10px" }} onClick={onRemove} disabled={disabled}>
             Remove
           </button>
         </div>

--- a/web/src/components/DocPanel.tsx
+++ b/web/src/components/DocPanel.tsx
@@ -1,10 +1,13 @@
-import { useEffect, useMemo } from "react";
-import { useSelection, type QtyMeta } from "../store/selection";
+import { useEffect, useMemo, useState } from "react";
+import QuantityEditPanel from "./QuantityEditPanel";
+import { useSelection, type QtyMeta, type Selected } from "../store/selection";
 
 type Props = {
   editableMode: boolean;
   blockedReason?: string | null;
+  actionError?: string | null;
   onRemoveQuantity: (id: string) => void;
+  onEditQuantity: (id: string, updates: { quantityName: string; dtype: string; docstring: string }) => void;
   clearActionError: () => void;
 };
 
@@ -45,12 +48,26 @@ function QtyRow({ q, onClick, onEdit, onRemove, editableMode, disabled }: { q: Q
   );
 }
 
-export default function DocPanel({ editableMode, onRemoveQuantity, blockedReason, clearActionError }: Props) {
+export default function DocPanel({
+  editableMode,
+  onRemoveQuantity,
+  onEditQuantity,
+  blockedReason,
+  actionError,
+  clearActionError,
+}: Props) {
   const { selected, setSelected } = useSelection();
+  const [classContext, setClassContext] = useState<Selected | null>(null);
 
   useEffect(() => {
     clearActionError();
   }, [selected, clearActionError]);
+
+  useEffect(() => {
+    if (selected?.kind === "class") {
+      setClassContext(selected);
+    }
+  }, [selected]);
 
   const disableActions = useMemo(() => !!blockedReason || !editableMode, [blockedReason, editableMode]);
 
@@ -62,6 +79,9 @@ export default function DocPanel({ editableMode, onRemoveQuantity, blockedReason
   };
 
   const showQuantity = (q: QtyMeta) => {
+    if (selected?.kind === "class") {
+      setClassContext(selected);
+    }
     setSelected({
       id: q.id,
       kind: "quantity",
@@ -74,6 +94,14 @@ export default function DocPanel({ editableMode, onRemoveQuantity, blockedReason
       card: q.card,
       owner: q.owner
     });
+  };
+
+  const goBackToClass = () => {
+    if (classContext) {
+      setSelected(classContext);
+    } else {
+      setSelected(null);
+    }
   };
 
   return (
@@ -116,15 +144,22 @@ export default function DocPanel({ editableMode, onRemoveQuantity, blockedReason
         </>
       ) : (
         <>
-          <div className="doc-header">
-            <div className="meta-label">Quantity</div>
+          <div className="doc-header" style={{ justifyContent: "space-between", gap: 10 }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+              <button className="btn secondary" type="button" onClick={goBackToClass} disabled={!classContext}>
+                ← Back
+              </button>
+              <div>
+                <div className="meta-label">Quantity</div>
+                <h2 className="doc-title" style={{ margin: "4px 0" }}>{selected.name}</h2>
+              </div>
+            </div>
             {(selected.path || selected.line) && (
               <div className="code-badge">
                 {selected.path}{selected.line ? `:${selected.line}` : ""}
               </div>
             )}
           </div>
-          <h2 className="doc-title">{selected.name}</h2>
           <div className="doc-meta">
             {[selected.dtype, selected.shape && selected.shape !== "[]"
               ? selected.shape
@@ -132,6 +167,17 @@ export default function DocPanel({ editableMode, onRemoveQuantity, blockedReason
               .filter(Boolean).join("  ")}
           </div>
           <pre className="doc-docstring">{selected.doc || "No docstring available."}</pre>
+
+          <div style={{ marginTop: 14, paddingTop: 10, borderTop: "1px solid var(--panel-border)" }}>
+            <QuantityEditPanel
+              editableMode={editableMode}
+              blockedReason={blockedReason}
+              actionError={actionError}
+              clearActionError={clearActionError}
+              onEditQuantity={onEditQuantity}
+              onRemoveQuantity={onRemoveQuantity}
+            />
+          </div>
         </>
       )}
     </div>

--- a/web/src/components/DocPanel.tsx
+++ b/web/src/components/DocPanel.tsx
@@ -1,23 +1,78 @@
+import { useEffect, useMemo, useState } from "react";
 import { useSelection, type QtyMeta } from "../store/selection";
+import { SUPPORTED_DTYPES, type QuantityFormData } from "./quantityShared";
 
-function QtyRow({ q, onClick }: { q: QtyMeta; onClick: () => void }) {
+type Props = {
+  editableMode: boolean;
+  blockedReason?: string | null;
+  actionError?: string | null;
+  onEditQuantity: (id: string, updates: QuantityFormData) => void;
+  onRemoveQuantity: (id: string) => void;
+  clearActionError: () => void;
+};
+
+function QtyRow({ q, onClick, onEdit, onRemove, editableMode, disabled }: { q: QtyMeta; onClick: () => void; onEdit: () => void; onRemove: () => void; editableMode: boolean; disabled: boolean }) {
   const meta: string[] = [];
   if (q.dtype) meta.push(q.dtype);
   if (q.shape && q.shape !== "[]") meta.push(q.shape);
   if (q.card) meta.push(`[${q.card}]`);
   return (
-    <button className="qty-row" onClick={onClick}>
-      <div style={{ flex: 1 }} className="qty-mono">
-        <div style={{ fontSize: 13 }}>{q.name}</div>
-        <div style={{ fontSize: 11, opacity: 0.7 }}>{meta.join("  ")}</div>
-      </div>
-      <div className="tag" style={{ borderColor: "rgba(124, 58, 237, 0.4)", color: "#c7d2fe" }}>View</div>
-    </button>
+    <div className="qty-row" style={{ gap: 8 }}>
+      <button className="qty-row" onClick={onClick} style={{ flex: 1 }}>
+        <div style={{ flex: 1 }} className="qty-mono">
+          <div style={{ fontSize: 13 }}>{q.name}</div>
+          <div style={{ fontSize: 11, opacity: 0.7 }}>{meta.join("  ")}</div>
+        </div>
+        <div className="tag" style={{ borderColor: "rgba(124, 58, 237, 0.4)", color: "#c7d2fe" }}>View</div>
+      </button>
+
+      {editableMode && (
+        <div className="row" style={{ gap: 6 }}>
+          <button className="btn secondary" style={{ padding: "6px 10px" }} onClick={onEdit} disabled={disabled}>
+            Edit
+          </button>
+          <button className="btn secondary" style={{ padding: "6px 10px" }} onClick={onRemove} disabled={disabled}>
+            Remove
+          </button>
+        </div>
+      )}
+    </div>
   );
 }
 
-export default function DocPanel() {
+export default function DocPanel({ editableMode, onEditQuantity, onRemoveQuantity, blockedReason, actionError, clearActionError }: Props) {
   const { selected, setSelected } = useSelection();
+  const [editing, setEditing] = useState<QtyMeta | null>(null);
+  const [formName, setFormName] = useState("");
+  const [formDtype, setFormDtype] = useState(SUPPORTED_DTYPES[0]);
+  const [formDoc, setFormDoc] = useState("");
+
+  useEffect(() => {
+    setEditing(null);
+    clearActionError();
+  }, [selected, clearActionError]);
+
+  useEffect(() => {
+    if (!editing) return;
+    setFormName(editing.name);
+    setFormDtype(editing.dtype || SUPPORTED_DTYPES[0]);
+    setFormDoc(editing.doc || "");
+  }, [editing]);
+
+  const disableActions = useMemo(() => !!blockedReason || !editableMode, [blockedReason, editableMode]);
+
+  const commitEdit = () => {
+    if (!editing) return;
+    onEditQuantity(editing.id, { quantityName: formName, dtype: formDtype, docstring: formDoc });
+  };
+
+  const confirmRemove = (id: string) => {
+    if (!editableMode || disableActions) return;
+    if (confirm("Remove this quantity from the current diagram?")) {
+      onRemoveQuantity(id);
+      setEditing(null);
+    }
+  };
 
   const showQuantity = (q: QtyMeta) => {
     setSelected({
@@ -33,6 +88,66 @@ export default function DocPanel() {
       owner: q.owner
     });
   };
+
+  const renderEditPanel = () => (
+    <div className="panel" style={{ marginTop: 10, display: "flex", flexDirection: "column", gap: 10 }}>
+      <div className="doc-subtitle" style={{ margin: 0 }}>Edit quantity</div>
+      <div>
+        <label className="label" htmlFor="edit-name">Name</label>
+        <input
+          id="edit-name"
+          className="input"
+          value={formName}
+          onChange={(e) => setFormName(e.target.value)}
+          disabled={disableActions}
+        />
+      </div>
+      <div>
+        <label className="label" htmlFor="edit-dtype">Type</label>
+        <select
+          id="edit-dtype"
+          className="select"
+          value={formDtype}
+          onChange={(e) => setFormDtype(e.target.value)}
+          disabled={disableActions}
+        >
+          {SUPPORTED_DTYPES.map((t) => (
+            <option key={t} value={t}>{t}</option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <label className="label" htmlFor="edit-doc">Docstring</label>
+        <textarea
+          id="edit-doc"
+          className="input"
+          style={{ minHeight: 80, resize: "vertical" }}
+          value={formDoc}
+          onChange={(e) => setFormDoc(e.target.value)}
+          disabled={disableActions}
+        />
+      </div>
+
+      {actionError && <div style={{ color: "#b91c1c", fontSize: 13 }}>{actionError}</div>}
+      {blockedReason && <div style={{ color: "#6b7280", fontSize: 13 }}>{blockedReason}</div>}
+
+      <div className="row" style={{ justifyContent: "space-between", gap: 8 }}>
+        <button className="btn secondary" type="button" onClick={() => setEditing(null)}>
+          Cancel
+        </button>
+        <div className="row" style={{ gap: 6 }}>
+          {editing ? (
+            <button className="btn secondary" type="button" onClick={() => confirmRemove(editing.id)} disabled={disableActions}>
+              Remove
+            </button>
+          ) : null}
+          <button className="btn" type="button" onClick={commitEdit} disabled={disableActions || !formName.trim()}>
+            Save changes
+          </button>
+        </div>
+      </div>
+    </div>
+  );
 
   return (
     <div className="doc-shell">
@@ -57,12 +172,32 @@ export default function DocPanel() {
           </div>
           <div className="doc-card" style={{ display: "flex", flexDirection: "column", gap: 8 }}>
             {(selected.quantities ?? []).map((q) => (
-              <QtyRow key={q.id} q={q} onClick={() => showQuantity(q)} />
+              <QtyRow
+                key={q.id}
+                q={q}
+                onClick={() => showQuantity(q)}
+                onEdit={() => setEditing(q)}
+                onRemove={() => confirmRemove(q.id)}
+                editableMode={editableMode}
+                disabled={disableActions}
+              />
             ))}
             {(!selected.quantities || selected.quantities.length === 0) && (
               <div style={{ fontSize: 12, opacity: 0.6 }}>No quantities found.</div>
             )}
           </div>
+
+          {editableMode && (
+            editing ? (
+              renderEditPanel()
+            ) : (
+              <div className="panel" style={{ marginTop: 10 }}>
+                <div style={{ color: "#6b7280", fontSize: 13 }}>
+                  {blockedReason || "Pick a quantity to edit or remove it from the current diagram."}
+                </div>
+              </div>
+            )
+          )}
         </>
       ) : (
         <>
@@ -82,6 +217,18 @@ export default function DocPanel() {
               .filter(Boolean).join("  ")}
           </div>
           <pre className="doc-docstring">{selected.doc || "No docstring available."}</pre>
+
+          {editableMode && selected.owner ? (
+            editing ? (
+              renderEditPanel()
+            ) : (
+              <div className="row" style={{ marginTop: 10, justifyContent: "flex-end" }}>
+                <button className="btn" onClick={() => setEditing({ ...selected, owner: selected.owner || "", id: selected.id })} disabled={disableActions}>
+                  Edit this quantity
+                </button>
+              </div>
+            )
+          ) : null}
         </>
       )}
     </div>

--- a/web/src/components/DocPanel.tsx
+++ b/web/src/components/DocPanel.tsx
@@ -1,12 +1,9 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo } from "react";
 import { useSelection, type QtyMeta } from "../store/selection";
-import { SUPPORTED_DTYPES, type QuantityFormData } from "./quantityShared";
 
 type Props = {
   editableMode: boolean;
   blockedReason?: string | null;
-  actionError?: string | null;
-  onEditQuantity: (id: string, updates: QuantityFormData) => void;
   onRemoveQuantity: (id: string) => void;
   clearActionError: () => void;
 };
@@ -48,40 +45,19 @@ function QtyRow({ q, onClick, onEdit, onRemove, editableMode, disabled }: { q: Q
   );
 }
 
-export default function DocPanel({ editableMode, onEditQuantity, onRemoveQuantity, blockedReason, actionError, clearActionError }: Props) {
+export default function DocPanel({ editableMode, onRemoveQuantity, blockedReason, clearActionError }: Props) {
   const { selected, setSelected } = useSelection();
-  const [editing, setEditing] = useState<QtyMeta | null>(null);
-  const [formName, setFormName] = useState("");
-  const [formDtype, setFormDtype] = useState(SUPPORTED_DTYPES[0]);
-  const [formDoc, setFormDoc] = useState("");
 
   useEffect(() => {
-    // Preserve the edit session when switching from a class to one of its quantities.
-    if (selected?.kind !== "quantity") {
-      setEditing(null);
-    }
     clearActionError();
   }, [selected, clearActionError]);
 
-  useEffect(() => {
-    if (!editing) return;
-    setFormName(editing.name);
-    setFormDtype(editing.dtype || SUPPORTED_DTYPES[0]);
-    setFormDoc(editing.doc || "");
-  }, [editing]);
-
   const disableActions = useMemo(() => !!blockedReason || !editableMode, [blockedReason, editableMode]);
-
-  const commitEdit = () => {
-    if (!editing) return;
-    onEditQuantity(editing.id, { quantityName: formName, dtype: formDtype, docstring: formDoc });
-  };
 
   const confirmRemove = (id: string) => {
     if (!editableMode || disableActions) return;
     if (confirm("Remove this quantity from the current diagram?")) {
       onRemoveQuantity(id);
-      setEditing(null);
     }
   };
 
@@ -99,66 +75,6 @@ export default function DocPanel({ editableMode, onEditQuantity, onRemoveQuantit
       owner: q.owner
     });
   };
-
-  const renderEditPanel = () => (
-    <div className="panel" style={{ marginTop: 10, display: "flex", flexDirection: "column", gap: 10 }}>
-      <div className="doc-subtitle" style={{ margin: 0 }}>Edit quantity</div>
-      <div>
-        <label className="label" htmlFor="edit-name">Name</label>
-        <input
-          id="edit-name"
-          className="input"
-          value={formName}
-          onChange={(e) => setFormName(e.target.value)}
-          disabled={disableActions}
-        />
-      </div>
-      <div>
-        <label className="label" htmlFor="edit-dtype">Type</label>
-        <select
-          id="edit-dtype"
-          className="select"
-          value={formDtype}
-          onChange={(e) => setFormDtype(e.target.value)}
-          disabled={disableActions}
-        >
-          {SUPPORTED_DTYPES.map((t) => (
-            <option key={t} value={t}>{t}</option>
-          ))}
-        </select>
-      </div>
-      <div>
-        <label className="label" htmlFor="edit-doc">Docstring</label>
-        <textarea
-          id="edit-doc"
-          className="input"
-          style={{ minHeight: 80, resize: "vertical" }}
-          value={formDoc}
-          onChange={(e) => setFormDoc(e.target.value)}
-          disabled={disableActions}
-        />
-      </div>
-
-      {actionError && <div style={{ color: "#b91c1c", fontSize: 13 }}>{actionError}</div>}
-      {blockedReason && <div style={{ color: "#6b7280", fontSize: 13 }}>{blockedReason}</div>}
-
-      <div className="row" style={{ justifyContent: "space-between", gap: 8 }}>
-        <button className="btn secondary" type="button" onClick={() => setEditing(null)}>
-          Cancel
-        </button>
-        <div className="row" style={{ gap: 6 }}>
-          {editing ? (
-            <button className="btn secondary" type="button" onClick={() => confirmRemove(editing.id)} disabled={disableActions}>
-              Remove
-            </button>
-          ) : null}
-          <button className="btn" type="button" onClick={commitEdit} disabled={disableActions || !formName.trim()}>
-            Save changes
-          </button>
-        </div>
-      </div>
-    </div>
-  );
 
   return (
     <div className="doc-shell">
@@ -187,7 +103,7 @@ export default function DocPanel({ editableMode, onEditQuantity, onRemoveQuantit
                 key={q.id}
                 q={q}
                 onClick={() => showQuantity(q)}
-                onEdit={() => setEditing(q)}
+                onEdit={() => showQuantity(q)}
                 onRemove={() => confirmRemove(q.id)}
                 editableMode={editableMode}
                 disabled={disableActions}
@@ -197,18 +113,6 @@ export default function DocPanel({ editableMode, onEditQuantity, onRemoveQuantit
               <div style={{ fontSize: 12, opacity: 0.6 }}>No quantities found.</div>
             )}
           </div>
-
-          {editableMode && (
-            editing ? (
-              renderEditPanel()
-            ) : (
-              <div className="panel" style={{ marginTop: 10 }}>
-                <div style={{ color: "#6b7280", fontSize: 13 }}>
-                  {blockedReason || "Pick a quantity to edit or remove it from the current diagram."}
-                </div>
-              </div>
-            )
-          )}
         </>
       ) : (
         <>
@@ -228,18 +132,6 @@ export default function DocPanel({ editableMode, onEditQuantity, onRemoveQuantit
               .filter(Boolean).join("  ")}
           </div>
           <pre className="doc-docstring">{selected.doc || "No docstring available."}</pre>
-
-          {editableMode && selected.owner ? (
-            editing ? (
-              renderEditPanel()
-            ) : (
-              <div className="row" style={{ marginTop: 10, justifyContent: "flex-end" }}>
-                <button className="btn" onClick={() => setEditing({ ...selected, owner: selected.owner || "", id: selected.id })} disabled={disableActions}>
-                  Edit this quantity
-                </button>
-              </div>
-            )
-          ) : null}
         </>
       )}
     </div>

--- a/web/src/components/DocPanel.tsx
+++ b/web/src/components/DocPanel.tsx
@@ -56,7 +56,10 @@ export default function DocPanel({ editableMode, onEditQuantity, onRemoveQuantit
   const [formDoc, setFormDoc] = useState("");
 
   useEffect(() => {
-    setEditing(null);
+    // Preserve the edit session when switching from a class to one of its quantities.
+    if (selected?.kind !== "quantity") {
+      setEditing(null);
+    }
     clearActionError();
   }, [selected, clearActionError]);
 

--- a/web/src/components/QuantityEditPanel.tsx
+++ b/web/src/components/QuantityEditPanel.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useMemo, useState } from "react";
+import { useSelection } from "../store/selection";
+import { SUPPORTED_DTYPES, type QuantityFormData } from "./quantityShared";
+
+type Props = {
+  editableMode: boolean;
+  blockedReason?: string | null;
+  actionError?: string | null;
+  clearActionError: () => void;
+  onEditQuantity: (id: string, updates: QuantityFormData) => void;
+  onRemoveQuantity: (id: string) => void;
+};
+
+export default function QuantityEditPanel({
+  editableMode,
+  blockedReason,
+  actionError,
+  clearActionError,
+  onEditQuantity,
+  onRemoveQuantity,
+}: Props) {
+  const { selected } = useSelection();
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [formName, setFormName] = useState("");
+  const [formDtype, setFormDtype] = useState(SUPPORTED_DTYPES[0]);
+  const [formDoc, setFormDoc] = useState("");
+
+  const disableActions = useMemo(() => !!blockedReason || !editableMode, [blockedReason, editableMode]);
+
+  useEffect(() => {
+    clearActionError();
+    if (selected?.kind === "quantity" && selected.owner) {
+      setEditingId(selected.id);
+      setFormName(selected.name);
+      setFormDtype(selected.dtype || SUPPORTED_DTYPES[0]);
+      setFormDoc(selected.doc || "");
+    } else {
+      setEditingId(null);
+    }
+  }, [selected, clearActionError]);
+
+  const commitEdit = () => {
+    if (!editingId) return;
+    onEditQuantity(editingId, { quantityName: formName, dtype: formDtype, docstring: formDoc });
+  };
+
+  const confirmRemove = () => {
+    if (!editingId || !editableMode || disableActions) return;
+    if (confirm("Remove this quantity from the current diagram?")) {
+      onRemoveQuantity(editingId);
+    }
+  };
+
+  const showSelectionHint = () => {
+    if (!editableMode) {
+      return "Enable editable mode to modify quantities.";
+    }
+    if (blockedReason) {
+      return blockedReason;
+    }
+    return "Select a quantity in the documentation panel to edit or remove it.";
+  };
+
+  return (
+    <div className="action-stack" style={{ gap: 12 }}>
+      {!editingId ? (
+        <div style={{ color: "#6b7280", fontSize: 13 }}>{showSelectionHint()}</div>
+      ) : (
+        <>
+          <div className="row" style={{ justifyContent: "space-between", alignItems: "center", gap: 8 }}>
+            <div className="doc-subtitle" style={{ margin: 0 }}>Edit quantity</div>
+            {(selected?.path || selected?.line) && (
+              <div className="code-badge" style={{ background: "rgba(255,255,255,0.02)" }}>
+                <span>{selected?.path}{selected?.line ? `:${selected.line}` : ""}</span>
+              </div>
+            )}
+          </div>
+
+          <div>
+            <label className="label" htmlFor="edit-name">Name</label>
+            <input
+              id="edit-name"
+              className="input"
+              value={formName}
+              onChange={(e) => setFormName(e.target.value)}
+              disabled={disableActions}
+            />
+          </div>
+
+          <div>
+            <label className="label" htmlFor="edit-dtype">Type</label>
+            <select
+              id="edit-dtype"
+              className="select"
+              value={formDtype}
+              onChange={(e) => setFormDtype(e.target.value)}
+              disabled={disableActions}
+            >
+              {SUPPORTED_DTYPES.map((t) => (
+                <option key={t} value={t}>{t}</option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="label" htmlFor="edit-doc">Docstring</label>
+            <textarea
+              id="edit-doc"
+              className="input"
+              style={{ minHeight: 80, resize: "vertical" }}
+              value={formDoc}
+              onChange={(e) => setFormDoc(e.target.value)}
+              disabled={disableActions}
+            />
+          </div>
+
+          {actionError && <div style={{ color: "#b91c1c", fontSize: 13 }}>{actionError}</div>}
+          {blockedReason && <div style={{ color: "#6b7280", fontSize: 13 }}>{blockedReason}</div>}
+
+          <div className="row" style={{ justifyContent: "space-between", gap: 8 }}>
+            <button className="btn secondary" type="button" onClick={confirmRemove} disabled={disableActions}>
+              Remove
+            </button>
+            <button className="btn" type="button" onClick={commitEdit} disabled={disableActions || !formName.trim()}>
+              Save changes
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/quantityShared.ts
+++ b/web/src/components/quantityShared.ts
@@ -1,0 +1,7 @@
+export type QuantityFormData = {
+  quantityName: string;
+  dtype: string;
+  docstring: string;
+};
+
+export const SUPPORTED_DTYPES = ["bool", "datetime", "float", "int", "str"] as const;


### PR DESCRIPTION
## Summary
- add shared quantity form constants for reuse
- provide editable-mode UI to edit or remove quantities from the documentation panel
- update client-side graph manipulation to apply quantity edits/removals and refresh selection

## Testing
- npm run lint *(fails: existing @typescript-eslint/no-explicit-any and unused eslint-disable warnings in repo)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692efc6269a88320a1273fbef382c898)