### PR TITLE
Expand supported dtype options

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -12,12 +12,25 @@ from .routes_git import router as git_router
 from extractor.usage_index import UsageEntry, get_usage_for_section
 from .settings import SCHEMA_REPO, DEFAULT_BASE_PACKAGE, repo_for_base_namespace
 
+# Keep this list in sync with `web/src/components/quantityShared.ts`.
 SUPPORTED_CUSTOM_DTYPES = {
+    # Booleans / strings / datetime
     "bool",
-    "datetime",
-    "float",
-    "int",
     "str",
+    "datetime",
+    # Generic numbers
+    "int",
+    "float",
+    # NumPy-style integers
+    "int32",
+    "int64",
+    "np.int32",
+    "np.int64",
+    # NumPy-style floats
+    "float32",
+    "float64",
+    "np.float32",
+    "np.float64",
 }
 
 

--- a/web/src/components/quantityShared.ts
+++ b/web/src/components/quantityShared.ts
@@ -4,4 +4,23 @@ export type QuantityFormData = {
   docstring: string;
 };
 
-export const SUPPORTED_DTYPES = ["bool", "datetime", "float", "int", "str"] as const;
+// Keep this list in sync with `api/main.py`.
+export const SUPPORTED_DTYPES = [
+  // Booleans / strings / datetime
+  "bool",
+  "str",
+  "datetime",
+  // Generic numbers
+  "int",
+  "float",
+  // NumPy-style integers
+  "int32",
+  "int64",
+  "np.int32",
+  "np.int64",
+  // NumPy-style floats
+  "float32",
+  "float64",
+  "np.float32",
+  "np.float64",
+] as const;


### PR DESCRIPTION
## Summary
- expand allowed custom quantity dtypes to cover numpy-style float and int variants alongside existing options
- mirror the expanded dtype list in the UI so editable dropdowns expose the specialized types

## Testing
- python -m pytest api/tests/test_custom_quantity.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f127ed6188320a2be58a66b5d3d1a)