### PR TITLE
Add RDFS import and export support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Back end: **FastAPI** · Front end: **React + Cytoscape + ELK**.
   - Information is derived from `nomad-simulations` via a small introspection/indexing step in the backend.
 - **Branch comparison**: Choose two Git branches and render the diff with visual highlights.
 - **Namespace filtering**: Limit traversal to a base namespace; optionally include cross-module links.
+- **RDFS I/O**: Import RDFS schema files into the editor and export edited diagrams back to RDFS.
 
 ---
 

--- a/api/main.py
+++ b/api/main.py
@@ -1,7 +1,7 @@
 from typing import List, Optional
 
 from fastapi import FastAPI, Query, HTTPException
-from fastapi.responses import ORJSONResponse
+from fastapi.responses import ORJSONResponse, PlainTextResponse
 from extractor.graph_builder import build_graph, list_sections
 from fastapi.middleware.cors import CORSMiddleware
 import os, subprocess, tempfile, shutil, ast
@@ -11,6 +11,7 @@ from pydantic import BaseModel
 from .routes_git import router as git_router
 from extractor.usage_index import UsageEntry, get_usage_for_section
 from .settings import SCHEMA_REPO, DEFAULT_BASE_PACKAGE, repo_for_base_namespace
+from .rdfs_io import graph_to_rdfs, rdfs_to_graph
 
 # Keep this list in sync with `web/src/components/quantityShared.ts`.
 SUPPORTED_CUSTOM_DTYPES = {
@@ -193,6 +194,43 @@ class CustomQuantityRequest(BaseModel):
     quantity_name: str
     dtype: str
     docstring: str | None = None
+
+
+class RdfsExportRequest(BaseModel):
+    graph: dict
+    base_uri: str | None = None
+    format: str = "turtle"
+
+
+class RdfsImportRequest(BaseModel):
+    data: str
+    format: str = "turtle"
+    package: str | None = None
+    base_uri: str | None = None
+
+
+@app.post("/schema/rdfs/export")
+def export_rdfs(req: RdfsExportRequest):
+    """Serialize the current graph payload to an RDFS document."""
+    try:
+        rdf_text = graph_to_rdfs(req.graph, base_uri=req.base_uri, rdf_format=req.format or "turtle")
+        return PlainTextResponse(rdf_text, media_type="text/plain")
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"{type(e).__name__}: {e}")
+
+
+@app.post("/schema/rdfs/import")
+def import_rdfs(req: RdfsImportRequest):
+    """Read an RDFS document and convert it to the graph payload format used in the UI."""
+    try:
+        return rdfs_to_graph(
+            req.data,
+            rdf_format=req.format or "turtle",
+            package_hint=req.package,
+            base_uri=req.base_uri,
+        )
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"{type(e).__name__}: {e}")
 
 
 def _attach_custom_quantity(graph: dict, req: CustomQuantityRequest) -> dict:

--- a/api/rdfs_io.py
+++ b/api/rdfs_io.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+from urllib.parse import quote, unquote
+
+from rdflib import Graph, Literal, Namespace, URIRef
+from rdflib.namespace import RDF, RDFS, XSD
+
+SCHEMA_UML = Namespace("https://schema-uml.nomad-lab.eu/schema#")
+
+DTYPE_TO_XSD = {
+    "bool": XSD.boolean,
+    "boolean": XSD.boolean,
+    "str": XSD.string,
+    "string": XSD.string,
+    "int": XSD.integer,
+    "float": XSD.double,
+    "float64": XSD.double,
+    "float32": XSD.float,
+    "datetime": XSD.dateTime,
+}
+
+
+def _normalize_base_uri(raw: Optional[str], package: Optional[str]) -> str:
+    if raw:
+        base = raw
+    else:
+        base = f"https://schema-uml.nomad-lab.eu/{package or 'schema'}#"
+    if not base.endswith(("#", "/")):
+        base = base + "#"
+    return base
+
+
+def _node_label(node: Dict[str, Any]) -> str:
+    return node.get("label") or node.get("name") or node.get("id") or "node"
+
+
+def _local_part(uri: URIRef) -> str:
+    text = str(uri)
+    if "#" in text:
+        return text.rsplit("#", 1)[-1]
+    if "/" in text:
+        return text.rsplit("/", 1)[-1]
+    return text
+
+
+def _unwrap_id(uri: URIRef, base: Optional[str]) -> str:
+    text = str(uri)
+    if base and text.startswith(base):
+        return unquote(text[len(base) :])
+    return text
+
+
+def _first_literal(graph: Graph, subject: URIRef, predicate: URIRef) -> Optional[str]:
+    for obj in graph.objects(subject, predicate):
+        if isinstance(obj, Literal):
+            return str(obj)
+    return None
+
+
+def _dtype_from_range(range_uri: Optional[URIRef]) -> Optional[str]:
+    if range_uri is None:
+        return None
+    text = str(range_uri)
+    for dtype, uri in DTYPE_TO_XSD.items():
+        if text == str(uri):
+            return dtype
+    return _local_part(range_uri)
+
+
+def _edge_cardinality(graph: Graph, subject: URIRef) -> Optional[str]:
+    for pred in (SCHEMA_UML.cardinality, SCHEMA_UML.edgeCardinality):
+        card = _first_literal(graph, subject, pred)
+        if card:
+            return card
+    return None
+
+
+def graph_to_rdfs(graph: Dict[str, Any], base_uri: Optional[str] = None, rdf_format: str = "turtle") -> str:
+    base = Namespace(_normalize_base_uri(base_uri, graph.get("package")))
+    rdf_graph = Graph()
+    rdf_graph.bind("rdfs", RDFS)
+    rdf_graph.bind("schemauml", SCHEMA_UML)
+    rdf_graph.bind("base", base)
+
+    node_uris: Dict[str, URIRef] = {}
+
+    def uri_for(node_id: str) -> URIRef:
+        if node_id not in node_uris:
+            node_uris[node_id] = URIRef(str(base) + quote(str(node_id)))
+        return node_uris[node_id]
+
+    for node in graph.get("nodes", []):
+        node_id = str(node.get("id"))
+        uri = uri_for(node_id)
+        kind = node.get("kind")
+        label = _node_label(node)
+        doc = node.get("doc")
+        module = node.get("module")
+        dtype = node.get("dtype")
+        shape = node.get("shape")
+        card = node.get("card")
+        owner = node.get("owner")
+
+        if kind == "section":
+            rdf_graph.add((uri, RDF.type, RDFS.Class))
+        else:
+            rdf_graph.add((uri, RDF.type, RDF.Property))
+        rdf_graph.add((uri, RDFS.label, Literal(label)))
+        rdf_graph.add((uri, SCHEMA_UML.kind, Literal(kind or "unknown")))
+
+        if doc:
+            rdf_graph.add((uri, RDFS.comment, Literal(doc)))
+        if module:
+            rdf_graph.add((uri, SCHEMA_UML.module, Literal(module)))
+        if dtype:
+            dtype_uri = DTYPE_TO_XSD.get(str(dtype))
+            if dtype_uri is not None:
+                rdf_graph.add((uri, RDFS.range, dtype_uri))
+            else:
+                rdf_graph.add((uri, SCHEMA_UML.dtype, Literal(str(dtype))))
+        if shape:
+            rdf_graph.add((uri, SCHEMA_UML.shape, Literal(shape)))
+        if card:
+            rdf_graph.add((uri, SCHEMA_UML.cardinality, Literal(card)))
+        if owner:
+            rdf_graph.add((uri, SCHEMA_UML.owner, uri_for(str(owner))))
+
+    for edge in graph.get("edges", []):
+        source = str(edge.get("source"))
+        target = str(edge.get("target"))
+        etype = edge.get("type")
+        card = edge.get("card")
+
+        src_uri = uri_for(source)
+        tgt_uri = uri_for(target)
+
+        if etype == "hasQuantity":
+            rdf_graph.add((src_uri, SCHEMA_UML.hasQuantity, tgt_uri))
+        elif etype == "hasSubSection":
+            rdf_graph.add((src_uri, SCHEMA_UML.hasSubSection, tgt_uri))
+        else:
+            rdf_graph.add((src_uri, SCHEMA_UML.relatedTo, tgt_uri))
+
+        if card:
+            rdf_graph.add((tgt_uri, SCHEMA_UML.cardinality, Literal(card)))
+
+    return rdf_graph.serialize(format=rdf_format)
+
+
+def rdfs_to_graph(
+    data: str,
+    rdf_format: str = "turtle",
+    package_hint: Optional[str] = None,
+    base_uri: Optional[str] = None,
+) -> Dict[str, Any]:
+    rdf_graph = Graph()
+    rdf_graph.parse(data=data, format=rdf_format)
+
+    decode_base = _normalize_base_uri(base_uri, package_hint) if base_uri else None
+    nodes: Dict[str, Dict[str, Any]] = {}
+    edges: list[Dict[str, Any]] = []
+    seen_edges: set[tuple[str, str, str]] = set()
+
+    def ensure_section(uri: URIRef) -> Dict[str, Any]:
+        uid = _unwrap_id(uri, decode_base)
+        if uid not in nodes:
+            nodes[uid] = {"id": uid, "kind": "section", "label": _local_part(uri)}
+        return nodes[uid]
+
+    has_quantity_pairs = list(rdf_graph.subject_objects(SCHEMA_UML.hasQuantity))
+    has_subsection_pairs = list(rdf_graph.subject_objects(SCHEMA_UML.hasSubSection))
+
+    for subj in rdf_graph.subjects(RDF.type, RDFS.Class):
+        node_id = _unwrap_id(subj, decode_base)
+        node = ensure_section(subj)
+        node["label"] = _first_literal(rdf_graph, subj, RDFS.label) or node.get("label")
+        node["doc"] = _first_literal(rdf_graph, subj, RDFS.comment)
+        node["module"] = _first_literal(rdf_graph, subj, SCHEMA_UML.module)
+        nodes[node_id] = node
+
+    for subj in rdf_graph.subjects(RDF.type, RDF.Property):
+        node_id = _unwrap_id(subj, decode_base)
+        label = _first_literal(rdf_graph, subj, RDFS.label) or _local_part(subj)
+        doc = _first_literal(rdf_graph, subj, RDFS.comment)
+        dtype = _first_literal(rdf_graph, subj, SCHEMA_UML.dtype)
+        shape = _first_literal(rdf_graph, subj, SCHEMA_UML.shape)
+        card = _edge_cardinality(rdf_graph, subj)
+        owner_uri = next(iter(rdf_graph.objects(subj, SCHEMA_UML.owner)), None)
+        if owner_uri is None:
+            owner_uri = next(iter(rdf_graph.objects(subj, RDFS.domain)), None)
+
+        range_uri = next(iter(rdf_graph.objects(subj, RDFS.range)), None)
+        inferred_dtype = _dtype_from_range(range_uri)
+        if inferred_dtype:
+            dtype = dtype or inferred_dtype
+
+        owner_id = _unwrap_id(owner_uri, decode_base) if owner_uri is not None else None
+        range_id = _unwrap_id(range_uri, decode_base) if range_uri is not None else None
+
+        node = {
+            "id": node_id,
+            "kind": "quantity",
+            "label": label,
+            "doc": doc,
+            "dtype": dtype,
+            "shape": shape,
+            "card": card,
+            "owner": owner_id,
+        }
+        nodes[node_id] = node
+
+        if owner_uri is not None:
+            add_edge = (owner_id, node_id, "hasQuantity")
+            if add_edge not in seen_edges:
+                edge: Dict[str, Any] = {"source": add_edge[0], "target": add_edge[1], "type": "hasQuantity"}
+                if card:
+                    edge["card"] = card
+                edges.append(edge)
+                seen_edges.add(add_edge)
+
+        if range_id is not None and range_id in nodes:
+            add_edge = (owner_id if owner_id is not None else node_id, range_id, "hasSubSection")
+            if add_edge not in seen_edges:
+                edge: Dict[str, Any] = {"source": add_edge[0], "target": add_edge[1], "type": "hasSubSection"}
+                edges.append(edge)
+                seen_edges.add(add_edge)
+
+    for src, tgt in has_quantity_pairs:
+        src_id = _unwrap_id(src, decode_base)
+        tgt_id = _unwrap_id(tgt, decode_base)
+        add_edge = (src_id, tgt_id, "hasQuantity")
+        if add_edge in seen_edges:
+            continue
+        ensure_section(src)
+        nodes.setdefault(tgt_id, {
+            "id": tgt_id,
+            "kind": "quantity",
+            "label": _local_part(tgt),
+            "owner": src_id,
+        })
+        edge: Dict[str, Any] = {"source": add_edge[0], "target": add_edge[1], "type": "hasQuantity"}
+        edges.append(edge)
+        seen_edges.add(add_edge)
+
+    for src, tgt in has_subsection_pairs:
+        src_id = _unwrap_id(src, decode_base)
+        tgt_id = _unwrap_id(tgt, decode_base)
+        add_edge = (src_id, tgt_id, "hasSubSection")
+        if add_edge in seen_edges:
+            continue
+        ensure_section(src)
+        ensure_section(tgt)
+        edge: Dict[str, Any] = {"source": add_edge[0], "target": add_edge[1], "type": "hasSubSection"}
+        edges.append(edge)
+        seen_edges.add(add_edge)
+
+    package = package_hint or (base_uri or str(rdf_graph.identifier) or "rdfs_schema")
+
+    return {
+        "package": package,
+        "root": None,
+        "base_uri": base_uri,
+        "nodes": list(nodes.values()),
+        "edges": edges,
+    }

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -5,3 +5,4 @@ networkx
 gitpython
 orjson
 httpx
+rdflib

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -5,4 +5,4 @@ networkx
 gitpython
 orjson
 httpx
-rdflib
+rdflib>=7.0.0,<8.0.0

--- a/api/tests/test_rdfs_io.py
+++ b/api/tests/test_rdfs_io.py
@@ -1,0 +1,82 @@
+import sys
+import textwrap
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from api.rdfs_io import graph_to_rdfs, rdfs_to_graph
+
+
+def test_roundtrip_preserves_quantities_and_sections():
+    graph = {
+        "package": "demo.schema",
+        "nodes": [
+            {"id": "demo.schema.Root", "kind": "section", "label": "Root", "doc": "Root doc"},
+            {
+                "id": "demo.schema.Root.value",
+                "kind": "quantity",
+                "label": "value",
+                "doc": "Value doc",
+                "dtype": "float",
+                "card": "0..1",
+                "owner": "demo.schema.Root",
+            },
+        ],
+        "edges": [
+            {"source": "demo.schema.Root", "target": "demo.schema.Root.value", "type": "hasQuantity", "card": "0..1"},
+        ],
+    }
+
+    rdf_text = graph_to_rdfs(graph, base_uri="https://example.org/schema#")
+    rebuilt = rdfs_to_graph(rdf_text, rdf_format="turtle", package_hint="demo.schema", base_uri="https://example.org/schema#")
+
+    ids = {n["id"] for n in rebuilt["nodes"]}
+    assert "demo.schema.Root" in ids
+    assert "demo.schema.Root.value" in ids
+
+    qty = next(n for n in rebuilt["nodes"] if n["kind"] == "quantity")
+    assert qty["dtype"] == "float"
+    assert qty["owner"] == "demo.schema.Root"
+
+    assert any(e for e in rebuilt["edges"] if e["type"] == "hasQuantity" and e["source"] == "demo.schema.Root")
+
+
+def test_imports_domain_and_range_relationships():
+    ttl = textwrap.dedent(
+        """
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+        @prefix ex: <https://example.org/schema#> .
+
+        ex:Person a rdfs:Class ; rdfs:label "Person" .
+        ex:Address a rdfs:Class ; rdfs:label "Address" .
+
+        ex:name a rdf:Property ;
+            rdfs:domain ex:Person ;
+            rdfs:range xsd:string ;
+            rdfs:label "name" .
+
+        ex:address a rdf:Property ;
+            rdfs:domain ex:Person ;
+            rdfs:range ex:Address ;
+            rdfs:label "address" .
+        """
+    )
+
+    graph = rdfs_to_graph(ttl, rdf_format="turtle", package_hint="example.schema", base_uri="https://example.org/schema#")
+
+    person = next(n for n in graph["nodes"] if n["label"] == "Person")
+    address_section = next(n for n in graph["nodes"] if n["label"] == "Address")
+    name_quantity = next(n for n in graph["nodes"] if n["label"] == "name")
+    address_quantity = next(n for n in graph["nodes"] if n["label"] == "address")
+
+    assert name_quantity["owner"] == person["id"]
+    assert address_quantity["owner"] == person["id"]
+    assert name_quantity["dtype"] in {"str", "string"}
+
+    assert any(
+        e for e in graph["edges"] if e["type"] == "hasSubSection" and e["source"] == person["id"] and e["target"] == address_section["id"]
+    )

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent } from "react";
 import axios from "axios";
 import GraphView, { type GraphExportHandle } from "./GraphView";
 import DocPanel from "./components/DocPanel";
@@ -81,6 +81,8 @@ export default function App() {
   const [quantityActionErr, setQuantityActionErr] = useState<string | null>(null);
 
   const [exportHandle, setExportHandle] = useState<GraphExportHandle | null>(null);
+  const [rdfsWorking, setRdfsWorking] = useState<boolean>(false);
+  const rdfsInputRef = useRef<HTMLInputElement | null>(null);
 
   const { selected, setSelected } = useSelection();
 
@@ -391,6 +393,78 @@ export default function App() {
     }
   };
 
+  const inferRdfsFormat = (filename: string) => {
+    const lower = filename.toLowerCase();
+    if (lower.endsWith(".rdf") || lower.endsWith(".rdfs") || lower.endsWith(".owl")) return "xml";
+    if (lower.endsWith(".ttl") || lower.endsWith(".turtle")) return "turtle";
+    return "turtle";
+  };
+
+  const exportRdfs = async () => {
+    if (!currentGraph) return;
+
+    setErr(null);
+    setRdfsWorking(true);
+    const baseUri =
+      (currentGraph as any).base_uri || `https://schema-uml.nomad-lab.eu/${currentGraph.package || "schema"}#`;
+
+    try {
+      const r = await api.post(
+        "/schema/rdfs/export",
+        { graph: currentGraph, base_uri: baseUri, format: "turtle" },
+        { responseType: "text" }
+      );
+
+      const blob = new Blob([r.data], { type: "text/turtle" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `${currentGraph.package}_${currentGraph.root || "all"}.ttl`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (e: any) {
+      setErr(e?.response?.data?.detail || String(e));
+    } finally {
+      setRdfsWorking(false);
+    }
+  };
+
+  const importRdfsFromFile = async (file: File) => {
+    setErr(null);
+    setRdfsWorking(true);
+    try {
+      const text = await file.text();
+      const r = await api.post(
+        "/schema/rdfs/import",
+        { data: text, format: inferRdfsFormat(file.name), package: pkg || undefined, base_uri: undefined },
+        { responseType: "json" }
+      );
+
+      setGraph(r.data);
+      setDiffData(null);
+      setMode("graph");
+      setSelected(null);
+      setQuantityActionErr(null);
+      setAddErr(null);
+      if (r.data?.package) setPkg(r.data.package);
+    } catch (e: any) {
+      setErr(e?.response?.data?.detail || String(e));
+    } finally {
+      setRdfsWorking(false);
+    }
+  };
+
+  const onRdfsFileChange = async (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      await importRdfsFromFile(file);
+    }
+    // allow re-uploading the same file
+    if (rdfsInputRef.current) {
+      rdfsInputRef.current.value = "";
+    }
+  };
+
   const exportJson = () => {
     if (!currentGraph) return;
     const s =
@@ -607,12 +681,12 @@ export default function App() {
               </label>
             </div>
 
-            <div className="row" style={{ marginTop: 14, justifyContent: "space-between", gap: 10 }}>
+            <div className="row" style={{ marginTop: 14, justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
               <button className="btn" onClick={loadGraph}>
                 Build graph
               </button>
               {currentGraph ? (
-                <div className="row" style={{ flex: 1, justifyContent: "flex-end" }}>
+                <div className="row" style={{ flex: 1, justifyContent: "flex-end", gap: 8, flexWrap: "wrap" }}>
                   <button className="btn secondary" onClick={exportJson}>
                     Export JSON
                   </button>
@@ -624,8 +698,28 @@ export default function App() {
                   >
                     Export PDF
                   </button>
+                  <button className="btn secondary" onClick={exportRdfs} disabled={rdfsWorking}>
+                    {rdfsWorking ? "Exporting…" : "Export RDFS"}
+                  </button>
                 </div>
               ) : null}
+            </div>
+            <div className="row" style={{ marginTop: 8, justifyContent: "flex-end", gap: 8, flexWrap: "wrap" }}>
+              <input
+                ref={rdfsInputRef}
+                type="file"
+                accept=".ttl,.rdf,.rdfs,.owl,text/turtle,application/rdf+xml"
+                style={{ display: "none" }}
+                onChange={onRdfsFileChange}
+              />
+              <button
+                className="btn secondary"
+                type="button"
+                onClick={() => rdfsInputRef.current?.click()}
+                disabled={rdfsWorking}
+              >
+                {rdfsWorking ? "Working…" : "Import RDFS"}
+              </button>
             </div>
 
             {err ? (


### PR DESCRIPTION
## Summary
- add backend support for serializing graphs to RDFS and reading RDFS schemas
- expose RDFS import/export controls in the UI and document the new capability
- cover the new functionality with rdflib dependency updates and tests

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f1b18d31c832080b9bbf0a2e199ca)