### PR TITLE
Improve overview navigation defaults

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -298,7 +298,7 @@ def overview(
         if not base_packages:
             raise HTTPException(status_code=400, detail="Provide at least one base package")
 
-        packages: dict[str, set[str]] = {}
+        modules: dict[str, set[str]] = {}
 
         for base_pkg in base_packages:
             repo = _repo_root(base_pkg)
@@ -330,18 +330,25 @@ def overview(
                     tail = str(rel_from_resolved).replace("/", ".")
                     package_name = base_pkg if tail in ("", ".") else f"{base_pkg}.{tail}"
 
-                    cls_names: set[str] = set()
                     for f in filenames:
-                        if f.endswith(".py"):
-                            cls_names.update(_collect_classes_from_file(pkg_dir / f))
+                        if not f.endswith(".py"):
+                            continue
 
-                    if package_name not in packages:
-                        packages[package_name] = set()
-                    packages[package_name].update(cls_names)
+                        module_name = package_name
+                        if f != "__init__.py":
+                            module_name = f"{package_name}.{Path(f).stem}"
+
+                        cls_names = _collect_classes_from_file(pkg_dir / f)
+                        if not cls_names:
+                            continue
+
+                        if module_name not in modules:
+                            modules[module_name] = set()
+                        modules[module_name].update(cls_names)
 
         items = [
-            PackageClasses(package=pkg, classes=sorted(classes))
-            for pkg, classes in sorted(packages.items())
+            PackageClasses(package=module, classes=sorted(classes))
+            for module, classes in sorted(modules.items())
         ]
 
         return OverviewOut(branch=branch, base=",".join(base_packages), items=items)

--- a/api/routes_git.py
+++ b/api/routes_git.py
@@ -173,12 +173,28 @@ def api_packages(
 
 
 @router.post("/graph")
-def api_graph(req: GraphRequest, base_namespace: str | None = Query(None)):
+def api_graph(
+    req: GraphRequest,
+    base_namespace: str | None = Query(None),
+    root: str | None = Query(None),
+    include_quantities: bool = Query(True),
+    include_subsections: bool = Query(True),
+    allow_cross_module: bool = Query(True),
+):
     pkg = req.package or DEFAULT_PACKAGE
     try:
         repo_src = _primary_repo(pkg, base_namespace)
         wt, sha = materialize_worktree(req.branch, repo_src)
-        graph = build_graph_in_subprocess(wt, pkg, req.extractor, base_namespace=base_namespace)
+        graph = build_graph_in_subprocess(
+            wt,
+            pkg,
+            req.extractor,
+            base_namespace=base_namespace,
+            root=root,
+            include_quantities=include_quantities,
+            include_subsections=include_subsections,
+            allow_cross_module=allow_cross_module,
+        )
         return {"branch": req.branch, "sha": sha, "graph": graph}
     except Exception as e:
         raise HTTPException(500, str(e))

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -716,14 +716,24 @@ export default function App() {
       {/* Main workspace: Graph + Doc Panel side-by-side */}
       <div className="workspace">
         {/* Left: graph area */}
-        <div style={{ minWidth: 0 }}>
+        <div
+          style={{
+            minWidth: 0,
+            display: "flex",
+            flexDirection: "column",
+            height: "100vh",
+            overflow: "hidden",
+          }}
+        >
           {mode === "overview" ? (
-            <OverviewGrid
-              apiBase={apiBase}
-              branch={overviewBranch}
-              base={normalizedNamespace}
-              onClassSelect={handleOverviewClassSelect}
-            />
+            <div style={{ flex: 1, minHeight: 0, overflow: "hidden" }}>
+              <OverviewGrid
+                apiBase={apiBase}
+                branch={overviewBranch}
+                base={normalizedNamespace}
+                onClassSelect={handleOverviewClassSelect}
+              />
+            </div>
           ) : diffData ? (
             <>
               <div className="workspace-toolbar">

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -722,11 +722,11 @@ export default function App() {
             display: "flex",
             flexDirection: "column",
             height: "100vh",
-            overflow: "hidden",
+            overflow: mode === "overview" ? "auto" : "hidden",
           }}
         >
           {mode === "overview" ? (
-            <div style={{ flex: 1, minHeight: 0, overflow: "hidden" }}>
+            <div style={{ flex: 1, minHeight: 0 }}>
               <OverviewGrid
                 apiBase={apiBase}
                 branch={overviewBranch}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -21,7 +21,7 @@ const DEFAULT_API = "http://localhost:5179";
 const DEFAULT_PACKAGE = import.meta.env.VITE_DEFAULT_PACKAGE ?? "nomad_simulations.schema_packages.model_method";
 const DEFAULT_NAMESPACE =
   import.meta.env.VITE_DEFAULT_NAMESPACE ??
-  "nomad_simulations.schema_packages,nomad_measurements";
+  "nomad_simulations.schema_packages";
 const DEFAULT_ROOT = import.meta.env.VITE_DEFAULT_ROOT ?? "ModelMethod";
 const DEFAULT_BRANCH = import.meta.env.VITE_DEFAULT_BRANCH ?? "develop";
 const WORKSPACE_PRESETS = [
@@ -42,7 +42,7 @@ const WORKSPACE_PRESETS = [
 ];
 
 export default function App() {
-  const [apiBase, setApiBase] = useState<string>(DEFAULT_API);
+  const apiBase = DEFAULT_API;
   const [pkg, setPkg] = useState<string>(DEFAULT_PACKAGE);
   const [availablePkgs, setAvailablePkgs] = useState<string[]>([]);
   const [roots, setRoots] = useState<string[]>([]);
@@ -91,7 +91,7 @@ export default function App() {
   const [overviewBranch, setOverviewBranch] = useState<string>(DEFAULT_BRANCH);
   const [packageBranch, setPackageBranch] = useState<string>(DEFAULT_BRANCH);
 
-  const api = useMemo(() => axios.create({ baseURL: apiBase }), [apiBase]);
+  const api = useMemo(() => axios.create({ baseURL: apiBase }), []);
   const normalizedNamespace = useMemo(() => {
     const parts = namespace.split(",").map((p) => p.trim()).filter(Boolean);
     return parts.length > 0 ? parts.join(",") : DEFAULT_NAMESPACE;
@@ -112,7 +112,10 @@ export default function App() {
   };
 
   // build single-branch graph (resets diff view)
-  const loadGraph = async () => {
+  const loadGraph = async (overrides?: { pkg?: string; root?: string; namespace?: string }) => {
+    const pkgToUse = overrides?.pkg ?? pkg;
+    const rootToUse = overrides?.root ?? root;
+    const namespaceToUse = overrides?.namespace ?? normalizedNamespace;
     setErr(null);
     setQuantityActionErr(null);
     setLoading(true);
@@ -121,12 +124,12 @@ export default function App() {
     try {
       const r = await api.get("/schema", {
         params: {
-          package: pkg,
-          root,
+          package: pkgToUse,
+          root: rootToUse,
           include_quantities: includeQuantities,
           include_subsections: includeSubsections,
           allow_cross_module: crossModules,
-          base_namespace: normalizedNamespace || undefined,
+          base_namespace: namespaceToUse || undefined,
         },
       });
       setGraph(r.data);
@@ -278,7 +281,7 @@ export default function App() {
   useEffect(() => {
     loadRoots();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pkg, apiBase]);
+  }, [pkg]);
 
   useEffect(() => {
     loadBranches();
@@ -297,6 +300,14 @@ export default function App() {
           : null;
 
   const currentGraph = diffData ? diffData.head?.graph ?? null : graph;
+
+  const handleOverviewClassSelect = (pkgName: string, className: string) => {
+    setMode("graph");
+    setPkg(pkgName);
+    setRoot(className);
+    setRoots((prev) => (prev.includes(className) ? prev : [className, ...prev]));
+    loadGraph({ pkg: pkgName, root: className, namespace: normalizedNamespace });
+  };
 
   const ensureEditableReady = () => {
     if (addBlockedReason) {
@@ -502,18 +513,8 @@ export default function App() {
           </div>
         </CollapsibleSection>
 
-        <CollapsibleSection title="API, package & filters" hint="Connect to a backend and fine-tune the graph">
+        <CollapsibleSection title="Package & filters" hint="Pick a backend package and fine-tune the graph">
           <div className="action-stack">
-            <div>
-              <label className="label">API base</label>
-              <input
-                className="input"
-                value={apiBase}
-                onChange={(e) => setApiBase(e.target.value)}
-                placeholder="http://localhost:5179"
-              />
-            </div>
-
             <div>
               <label className="label">Package</label>
               <input
@@ -608,7 +609,7 @@ export default function App() {
             </div>
 
             <div className="row" style={{ marginTop: 14, justifyContent: "space-between", gap: 10 }}>
-              <button className="btn" onClick={loadGraph}>
+              <button className="btn" onClick={() => loadGraph()}>
                 Build graph
               </button>
               {currentGraph ? (
@@ -688,7 +689,12 @@ export default function App() {
         {/* Left: graph area */}
         <div style={{ minWidth: 0 }}>
           {mode === "overview" ? (
-            <OverviewGrid apiBase={apiBase} branch={overviewBranch} base={normalizedNamespace} />
+            <OverviewGrid
+              apiBase={apiBase}
+              branch={overviewBranch}
+              base={normalizedNamespace}
+              onClassSelect={handleOverviewClassSelect}
+            />
           ) : diffData ? (
             <>
               <div className="workspace-toolbar">

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -112,27 +112,50 @@ export default function App() {
   };
 
   // build single-branch graph (resets diff view)
-  const loadGraph = async (overrides?: { pkg?: string; root?: string; namespace?: string }) => {
+  const loadGraph = async (
+    overrides?: { pkg?: string; root?: string; namespace?: string; branch?: string }
+  ) => {
     const pkgToUse = overrides?.pkg ?? pkg;
     const rootToUse = overrides?.root ?? root;
     const namespaceToUse = overrides?.namespace ?? normalizedNamespace;
+    const branchToUse = overrides?.branch ?? "";
     setErr(null);
     setQuantityActionErr(null);
     setLoading(true);
     setDiffData(null);
     setExportHandle(null);
     try {
-      const r = await api.get("/schema", {
-        params: {
-          package: pkgToUse,
-          root: rootToUse,
-          include_quantities: includeQuantities,
-          include_subsections: includeSubsections,
-          allow_cross_module: crossModules,
-          base_namespace: namespaceToUse || undefined,
-        },
-      });
-      setGraph(r.data);
+      if (branchToUse) {
+        const r = await api.post(
+          "/graph",
+          {
+            branch: branchToUse,
+            package: pkgToUse,
+          },
+          {
+            params: {
+              root: rootToUse,
+              include_quantities: includeQuantities,
+              include_subsections: includeSubsections,
+              allow_cross_module: crossModules,
+              base_namespace: namespaceToUse || undefined,
+            },
+          }
+        );
+        setGraph(r.data?.graph ?? null);
+      } else {
+        const r = await api.get("/schema", {
+          params: {
+            package: pkgToUse,
+            root: rootToUse,
+            include_quantities: includeQuantities,
+            include_subsections: includeSubsections,
+            allow_cross_module: crossModules,
+            base_namespace: namespaceToUse || undefined,
+          },
+        });
+        setGraph(r.data);
+      }
     } catch (e: any) {
       setErr(e?.response?.data?.detail || String(e));
       setGraph(null);
@@ -305,8 +328,14 @@ export default function App() {
     setMode("graph");
     setPkg(pkgName);
     setRoot(className);
+    setPackageBranch((prev) => prev || overviewBranch);
     setRoots((prev) => (prev.includes(className) ? prev : [className, ...prev]));
-    loadGraph({ pkg: pkgName, root: className, namespace: normalizedNamespace });
+    loadGraph({
+      pkg: pkgName,
+      root: className,
+      namespace: normalizedNamespace,
+      branch: overviewBranch,
+    });
   };
 
   const ensureEditableReady = () => {

--- a/web/src/GraphView.tsx
+++ b/web/src/GraphView.tsx
@@ -13,6 +13,8 @@ type RawNode = {
   label: string;
   module?: string;
   dtype?: string | null;
+  data_type?: string | null;
+  type?: string | null;
   shape?: string | null;
   card?: string | null;
   owner?: string | null;

--- a/web/src/components/AddQuantityForm.tsx
+++ b/web/src/components/AddQuantityForm.tsx
@@ -12,7 +12,7 @@ type Props = {
 
 export default function AddQuantityForm({ enabled, targetClass, onSubmit, submitting, error, blockedReason }: Props) {
   const [quantityName, setQuantityName] = useState("");
-  const [dtype, setDtype] = useState(SUPPORTED_DTYPES[0]);
+  const [dtype, setDtype] = useState<string>(SUPPORTED_DTYPES[0]);
   const [docstring, setDocstring] = useState("");
 
   const disabledReason = useMemo(() => {

--- a/web/src/components/OverviewGrid.tsx
+++ b/web/src/components/OverviewGrid.tsx
@@ -11,10 +11,12 @@ export default function OverviewGrid({
   apiBase,
   branch,
   base = DEFAULT_OVERVIEW_BASE,
+  onClassSelect,
 }: {
   apiBase: string;
   branch: string;
   base?: string;
+  onClassSelect?: (pkg: string, className: string) => void;
 }) {
   const [data, setData] = useState<OverviewResp | null>(null);
   const [q, setQ] = useState("");
@@ -128,19 +130,23 @@ export default function OverviewGrid({
               }}
             >
               {it.classes.map((c) => (
-                <span
+                <button
                   key={`${it.package}.${c}`}
+                  type="button"
+                  onClick={() => onClassSelect?.(it.package, c)}
                   style={{
                     fontSize: 11,
                     border: "1px solid #e5e7eb",
                     borderRadius: 9999,
-                    padding: "2px 8px",
-                    background: "#f9fafb",
+                    padding: "4px 10px",
+                    background: onClassSelect ? "#eef2ff" : "#f9fafb",
+                    cursor: onClassSelect ? "pointer" : "default",
+                    color: "#1f2937",
                   }}
                   title={c}
                 >
                   {c}
-                </span>
+                </button>
               ))}
             </div>
           </div>

--- a/web/src/components/OverviewGrid.tsx
+++ b/web/src/components/OverviewGrid.tsx
@@ -61,8 +61,17 @@ export default function OverviewGrid({
   if (!data) return <div className="p-2 text-sm">No data.</div>;
 
   return (
-    <div className="flex flex-col gap-2 h-full">
-      <div className="flex items-center gap-8">
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 12,
+        height: "100%",
+        minHeight: 0,
+        overflow: "hidden",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
         <input
           className="border rounded px-2 py-1"
           placeholder="Filter package or class…"
@@ -81,10 +90,11 @@ export default function OverviewGrid({
           gridTemplateColumns: "repeat(auto-fill, minmax(320px, 1fr))",
           gap: 12,
           alignContent: "start",
-          overflow: "auto",
+          overflowY: "auto",
           paddingBottom: 8,
+          flex: 1,
+          minHeight: 0,
         }}
-        className="flex-1"
       >
         {items.map((it) => (
           <div

--- a/web/src/components/QuantityEditPanel.tsx
+++ b/web/src/components/QuantityEditPanel.tsx
@@ -22,7 +22,7 @@ export default function QuantityEditPanel({
   const { selected } = useSelection();
   const [editingId, setEditingId] = useState<string | null>(null);
   const [formName, setFormName] = useState("");
-  const [formDtype, setFormDtype] = useState(SUPPORTED_DTYPES[0]);
+  const [formDtype, setFormDtype] = useState<string>(SUPPORTED_DTYPES[0]);
   const [formDoc, setFormDoc] = useState("");
 
   const disableActions = useMemo(() => !!blockedReason || !editableMode, [blockedReason, editableMode]);


### PR DESCRIPTION
## Summary
- default the workspace to the nomad-simulations preset and rely on the local API base without exposing a text box
- allow selecting a class from the bird's-eye overview to jump straight into its UML diagram
- tighten quantity form typing for supported dtypes and keep graph building button usage intact

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fde96fe04832080a283a43ad82129)