### PR TITLE
Add quantity-level diff support

### DIFF
--- a/api/diff.py
+++ b/api/diff.py
@@ -6,6 +6,17 @@ def index_graph(graph: Dict[str, Any]) -> Tuple[Dict[str, Dict], Set[Tuple[str,s
     edges = set((e["source"], e["target"], e.get("type","")) for e in graph.get("edges", []))
     return nodes, edges
 
+def _node_signature(node: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a reduced view of a node that captures meaningful diff fields."""
+
+    base_keys = ["label", "module", "kind"]
+    quantity_keys = ["dtype", "data_type", "type", "shape", "card", "owner", "doc"]
+    section_keys = ["doc", "methods"]
+
+    keys = base_keys + (quantity_keys if node.get("kind") == "quantity" else section_keys)
+    return {k: node.get(k) for k in keys}
+
+
 def diff_graphs(a: Dict[str, Any], b: Dict[str, Any]) -> Dict[str, Any]:
     an, ae = index_graph(a)
     bn, be = index_graph(b)
@@ -16,9 +27,8 @@ def diff_graphs(a: Dict[str, Any], b: Dict[str, Any]) -> Dict[str, Any]:
     common = set(an) & set(bn)
     changed_nodes = []
     for k in common:
-        # Compare minimal label fields (tweak as you like)
-        av = {x: an[k].get(x) for x in ("label", "module", "kind")}
-        bv = {x: bn[k].get(x) for x in ("label", "module", "kind")}
+        av = _node_signature(an[k])
+        bv = _node_signature(bn[k])
         if av != bv:
             changed_nodes.append({"id": k, "before": an[k], "after": bn[k]})
 

--- a/web/src/GraphView.tsx
+++ b/web/src/GraphView.tsx
@@ -3,7 +3,7 @@ import cytoscape from "cytoscape";
 import elk from "elkjs/lib/elk.bundled.js";
 import cytoscapeElk from "cytoscape-elk";
 import type { Core, ElementDefinition } from "cytoscape";
-import { useSelection, type QtyMeta } from "./store/selection";
+import { useSelection, type QtyMeta, type QtySnapshot } from "./store/selection";
 
 cytoscapeElk(cytoscape, elk as any);
 
@@ -90,6 +90,39 @@ export default function GraphView({ nodes, edges, diff, onReady }: Props) {
 
   const setSelected = useMemo(() => useSelection.getState().setSelected, []);
 
+  const quantityDiffs = useMemo(() => {
+    const map = new Map<
+      string,
+      { state: "added" | "removed" | "changed"; before?: RawNode; after?: RawNode }
+    >();
+
+    if (!diff) return map;
+
+    diff.nodes?.added?.forEach((n: any) => {
+      if (n?.kind === "quantity" && n.id) {
+        map.set(n.id, { state: "added", after: n });
+      }
+    });
+
+    diff.nodes?.removed?.forEach((n: any) => {
+      if (n?.kind === "quantity" && n.id) {
+        map.set(n.id, { state: "removed", before: n });
+      }
+    });
+
+    diff.nodes?.changed?.forEach((entry: any) => {
+      const before = entry?.before;
+      const after = entry?.after;
+      const id = entry?.id;
+      const isQuantity = before?.kind === "quantity" || after?.kind === "quantity";
+      if (isQuantity && id) {
+        map.set(id, { state: "changed", before, after });
+      }
+    });
+
+    return map;
+  }, [diff]);
+
   // Build:
   // - sectionsMap: id -> section node
   // - attrsMap: section id -> display lines for UML
@@ -100,6 +133,17 @@ export default function GraphView({ nodes, edges, diff, onReady }: Props) {
     const attrs = new Map<string, { name: string; dtype?: string; shape?: string | null; card?: string | null }[]>();
     const methods = new Map<string, string[]>();
     const qByOwner = new Map<string, QtyMeta[]>();
+
+    const buildSnapshot = (n?: RawNode | null): QtySnapshot | undefined => {
+      if (!n) return undefined;
+      return {
+        name: n.label,
+        dtype: n.dtype ?? (n as any).data_type ?? (n as any).type ?? undefined,
+        shape: n.shape ?? undefined,
+        card: n.card ?? undefined,
+        doc: n.doc ?? undefined,
+      };
+    };
 
     for (const n of nodes) {
       if (n.kind === "section") {
@@ -112,6 +156,8 @@ export default function GraphView({ nodes, edges, diff, onReady }: Props) {
 
     for (const q of nodes) {
       if (q.kind !== "quantity" || !q.owner) continue;
+
+      const diffInfo = quantityDiffs.get(q.id);
 
       // For UML card display
       const list = attrs.get(q.owner) ?? [];
@@ -134,14 +180,45 @@ export default function GraphView({ nodes, edges, diff, onReady }: Props) {
         doc: q.doc ?? undefined,
         path: q.path ?? undefined,
         line: typeof q.line === "number" ? q.line : undefined,
-        owner: q.owner
+        owner: q.owner,
+        diff: diffInfo
+          ? {
+              state: diffInfo.state,
+              before: buildSnapshot(diffInfo.before),
+              after: buildSnapshot(diffInfo.after),
+            }
+          : undefined,
       });
       qByOwner.set(q.owner, metaList);
     }
 
+    // Also surface removed quantities so they appear in the DocPanel list
+    for (const [qid, diffInfo] of quantityDiffs.entries()) {
+      if (diffInfo.state !== "removed") continue;
+      const owner = diffInfo.before?.owner;
+      if (!owner || !sections.has(owner)) continue;
+
+      const metaList = qByOwner.get(owner) ?? [];
+      metaList.push({
+        id: qid,
+        name: diffInfo.before?.label || qid.split(".").pop() || qid,
+        dtype:
+          diffInfo.before?.dtype ?? (diffInfo.before as any)?.data_type ?? (diffInfo.before as any)?.type ?? undefined,
+        shape: diffInfo.before?.shape ?? undefined,
+        card: diffInfo.before?.card ?? undefined,
+        doc: diffInfo.before?.doc ?? undefined,
+        owner,
+        diff: {
+          state: "removed",
+          before: buildSnapshot(diffInfo.before),
+        },
+      });
+      qByOwner.set(owner, metaList);
+    }
+
     const subs = edges.filter(e => e.type === "hasSubSection");
     return { sectionsMap: sections, attrsMap: attrs, methodsMap: methods, compEdges: subs, quantitiesByOwner: qByOwner };
-  }, [nodes, edges]);
+  }, [nodes, edges, quantityDiffs]);
 
   useEffect(() => {
     if (!containerRef.current) return;

--- a/web/src/GraphView.tsx
+++ b/web/src/GraphView.tsx
@@ -70,9 +70,9 @@ function umlLabel(
 
   const attrLines = shownA.map(a => {
     const parts = [] as string[];
-    if (a.diff === "added") parts.push("+ ");
-    if (a.diff === "removed") parts.push("- ");
-    if (a.diff === "changed") parts.push("~ ");
+    if (a.diff === "added") parts.push("🟢 ");
+    if (a.diff === "removed") parts.push("🔴 ");
+    if (a.diff === "changed") parts.push("🟠 ");
 
     parts.push(a.name);
     const dt = cleanType(a.dtype);

--- a/web/src/GraphView.tsx
+++ b/web/src/GraphView.tsx
@@ -5,6 +5,8 @@ import cytoscapeElk from "cytoscape-elk";
 import type { Core, ElementDefinition } from "cytoscape";
 import { useSelection, type QtyMeta, type QtySnapshot } from "./store/selection";
 
+type QtyDiffState = QtyMeta["diff"] extends { state: infer S } ? S : undefined;
+
 cytoscapeElk(cytoscape, elk as any);
 
 type RawNode = {
@@ -58,7 +60,7 @@ const cleanType = (t?: string | null) => {
 
 function umlLabel(
   name: string,
-  attrs: { name: string; dtype?: string; shape?: string | null; card?: string | null }[],
+  attrs: { name: string; dtype?: string; shape?: string | null; card?: string | null; diff?: QtyDiffState }[],
   methods: string[]
 ) {
   const MAX_A = 18;
@@ -67,7 +69,12 @@ function umlLabel(
   const shownM = methods.slice(0, MAX_M);
 
   const attrLines = shownA.map(a => {
-    const parts = [a.name];
+    const parts = [] as string[];
+    if (a.diff === "added") parts.push("+ ");
+    if (a.diff === "removed") parts.push("- ");
+    if (a.diff === "changed") parts.push("~ ");
+
+    parts.push(a.name);
     const dt = cleanType(a.dtype);
     if (dt) parts.push(`: ${dt}`);
     if (a.shape && a.shape !== "[]") parts.push(` ${a.shape}`);
@@ -123,6 +130,17 @@ export default function GraphView({ nodes, edges, diff, onReady }: Props) {
     return map;
   }, [diff]);
 
+  const graphNodes = useMemo(() => {
+    const base = [...nodes];
+    if (diff?.nodes?.removed?.length) {
+      diff.nodes.removed.forEach((n: any) => {
+        if (!n?.id || (n?.kind !== "section" && n?.kind !== "quantity")) return;
+        base.push(n as RawNode);
+      });
+    }
+    return base;
+  }, [nodes, diff]);
+
   // Build:
   // - sectionsMap: id -> section node
   // - attrsMap: section id -> display lines for UML
@@ -130,7 +148,10 @@ export default function GraphView({ nodes, edges, diff, onReady }: Props) {
   // - quantitiesByOwner: section id -> QtyMeta[]  (for DocPanel)
   const { sectionsMap, attrsMap, methodsMap, compEdges, quantitiesByOwner } = useMemo(() => {
     const sections = new Map<string, RawNode>();
-    const attrs = new Map<string, { name: string; dtype?: string; shape?: string | null; card?: string | null }[]>();
+    const attrs = new Map<
+      string,
+      { name: string; dtype?: string; shape?: string | null; card?: string | null; diff?: QtyDiffState }[]
+    >();
     const methods = new Map<string, string[]>();
     const qByOwner = new Map<string, QtyMeta[]>();
 
@@ -145,7 +166,7 @@ export default function GraphView({ nodes, edges, diff, onReady }: Props) {
       };
     };
 
-    for (const n of nodes) {
+    for (const n of graphNodes) {
       if (n.kind === "section") {
         sections.set(n.id, n);
         attrs.set(n.id, attrs.get(n.id) ?? []);
@@ -154,7 +175,7 @@ export default function GraphView({ nodes, edges, diff, onReady }: Props) {
       }
     }
 
-    for (const q of nodes) {
+    for (const q of graphNodes) {
       if (q.kind !== "quantity" || !q.owner) continue;
 
       const diffInfo = quantityDiffs.get(q.id);
@@ -165,7 +186,8 @@ export default function GraphView({ nodes, edges, diff, onReady }: Props) {
         name: q.label,
         dtype: q.dtype ?? q.data_type ?? q.type ?? undefined,
         shape: q.shape ?? undefined,
-        card: q.card ?? undefined
+        card: q.card ?? undefined,
+        diff: diffInfo?.state,
       });
       attrs.set(q.owner, list);
 
@@ -216,9 +238,22 @@ export default function GraphView({ nodes, edges, diff, onReady }: Props) {
       qByOwner.set(owner, metaList);
     }
 
-    const subs = edges.filter(e => e.type === "hasSubSection");
+    const baseEdges = [...edges];
+    if (diff?.edges?.removed?.length) {
+      diff.edges.removed.forEach((e: any) => {
+        if (!e?.source || !e?.target) return;
+        baseEdges.push({
+          source: e.source,
+          target: e.target,
+          type: (e.type as any) ?? "hasSubSection",
+          card: e.card ?? undefined
+        });
+      });
+    }
+
+    const subs = baseEdges.filter(e => e.type === "hasSubSection");
     return { sectionsMap: sections, attrsMap: attrs, methodsMap: methods, compEdges: subs, quantitiesByOwner: qByOwner };
-  }, [nodes, edges, quantityDiffs]);
+  }, [graphNodes, edges, quantityDiffs, diff]);
 
   useEffect(() => {
     if (!containerRef.current) return;

--- a/web/src/components/DocPanel.tsx
+++ b/web/src/components/DocPanel.tsx
@@ -16,6 +16,25 @@ function QtyRow({ q, onClick, onEdit, onRemove, editableMode, disabled }: { q: Q
   if (q.dtype) meta.push(q.dtype);
   if (q.shape && q.shape !== "[]") meta.push(q.shape);
   if (q.card) meta.push(`[${q.card}]`);
+
+  const diffLabel =
+    q.diff?.state === "added"
+      ? "Added"
+      : q.diff?.state === "removed"
+        ? "Removed"
+        : q.diff?.state === "changed"
+          ? "Changed"
+          : null;
+
+  const diffClass =
+    q.diff?.state === "added"
+      ? "pill"
+      : q.diff?.state === "removed"
+        ? "pill muted"
+        : q.diff?.state === "changed"
+          ? "pill warning"
+          : null;
+
   const handleClick = () => {
     if (editableMode && !disabled) {
       onEdit();
@@ -31,6 +50,7 @@ function QtyRow({ q, onClick, onEdit, onRemove, editableMode, disabled }: { q: Q
           <div style={{ fontSize: 13 }}>{q.name}</div>
           <div style={{ fontSize: 11, opacity: 0.7 }}>{meta.join("  ")}</div>
         </div>
+        {diffLabel ? <span className={diffClass || "pill"}>{diffLabel}</span> : null}
         <div className="tag" style={{ borderColor: "rgba(124, 58, 237, 0.4)", color: "#c7d2fe" }}>View</div>
       </button>
 
@@ -92,7 +112,8 @@ export default function DocPanel({
       dtype: q.dtype,
       shape: q.shape,
       card: q.card,
-      owner: q.owner
+      owner: q.owner,
+      diff: q.diff
     });
   };
 
@@ -169,6 +190,28 @@ export default function DocPanel({
           <pre className="doc-docstring">{selected.doc || "No docstring available."}</pre>
 
           <div style={{ marginTop: 14, paddingTop: 10, borderTop: "1px solid var(--panel-border)" }}>
+            {selected.diff ? (
+              <div className="doc-card" style={{ marginBottom: 12, background: "rgba(234, 179, 8, 0.05)" }}>
+                <div className="meta-label" style={{ marginBottom: 6 }}>
+                  Diff
+                </div>
+                <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                  <div>
+                    <strong>Status:</strong> {selected.diff.state}
+                  </div>
+                  {selected.diff.before ? (
+                    <div style={{ fontSize: 12 }}>
+                      <strong>Before:</strong> {[selected.diff.before.dtype, selected.diff.before.shape && selected.diff.before.shape !== "[]" ? selected.diff.before.shape : null, selected.diff.before.card ? `[${selected.diff.before.card}]` : null].filter(Boolean).join("  ") || "no metadata"}
+                    </div>
+                  ) : null}
+                  {selected.diff.after ? (
+                    <div style={{ fontSize: 12 }}>
+                      <strong>After:</strong> {[selected.diff.after.dtype, selected.diff.after.shape && selected.diff.after.shape !== "[]" ? selected.diff.after.shape : null, selected.diff.after.card ? `[${selected.diff.after.card}]` : null].filter(Boolean).join("  ") || "no metadata"}
+                    </div>
+                  ) : null}
+                </div>
+              </div>
+            ) : null}
             <QuantityEditPanel
               editableMode={editableMode}
               blockedReason={blockedReason}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -314,6 +314,8 @@ hr { border:0; border-top:1px solid var(--panel-border); margin:12px 0; }
 .toggle-chip:hover { transform: translateY(-1px); }
 
 .pill { padding: 6px 10px; border-radius: 999px; background: var(--pill-bg); color: var(--pill-color); font-size: 12px; }
+.pill.warning { background: rgba(234, 179, 8, 0.16); color: #fef9c3; }
+.pill.muted { background: rgba(148, 163, 184, 0.18); color: var(--muted); }
 
 .empty-state { padding: 32px; color: var(--muted); text-align: center; }
 

--- a/web/src/store/selection.ts
+++ b/web/src/store/selection.ts
@@ -1,5 +1,13 @@
 import { create } from 'zustand';
 
+export type QtySnapshot = {
+  name?: string;
+  dtype?: string;
+  shape?: string | null;
+  card?: string | null;
+  doc?: string | null;
+};
+
 export type QtyMeta = {
   id: string;
   name: string;
@@ -10,6 +18,7 @@ export type QtyMeta = {
   path?: string;
   line?: number;
   owner: string;
+  diff?: { state: 'added' | 'removed' | 'changed'; before?: QtySnapshot; after?: QtySnapshot };
 };
 
 export type Selected = null | {
@@ -25,6 +34,7 @@ export type Selected = null | {
   card?: string | null;
   owner?: string;
   fqid?: string;
+  diff?: QtyMeta['diff'];
 };
 
 type SelectionState = {


### PR DESCRIPTION
## Summary
- include quantity-specific fields when computing graph diffs so attribute changes are detected
- surface quantity diff metadata in the UI, including added/removed items and before/after snapshots for changes
- display diff badges and styling in the documentation panel while retaining the existing diagram layout

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fe9bc51f08320a067fcec5f49f363)