### PR TITLE
Update documentation for editable mode and frontend usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,15 @@
 
 Interactive UML-style viewer for NOMAD-compatible schemas (defaults to `nomad-simulations`).
 
-
 Back end: **FastAPI** · Front end: **React + Cytoscape + ELK**.
 
 - Visualizes **sections** as UML cards (attributes = quantities, edges = subsections).
 - Right-hand **Doc Panel** shows the **class docstring** and a **clickable list of quantities**.
 - Right-hand **Under the hood** panel shows **normalization and helper functions** that act on the selected section.
-- **Branch diff** (base → head) highlights **added/changed/removed** nodes/edges.
+- **Branch diff** (base → head) highlights **added/changed/removed** nodes/edges, including quantity changes.
+- **Bird's-eye overview**: inspect packages/classes across branches without building a full graph.
+- **Editable mode**: add, rename, or remove quantities directly in the UI (server validates supported dtypes).
+- **Export**: download the current graph as JSON or a PDF snapshot.
 
 ---
 
@@ -27,6 +29,9 @@ Back end: **FastAPI** · Front end: **React + Cytoscape + ELK**.
   - Information is derived from `nomad-simulations` via a small introspection/indexing step in the backend.
 - **Branch comparison**: Choose two Git branches and render the diff with visual highlights.
 - **Namespace filtering**: Limit traversal to a base namespace; optionally include cross-module links.
+- **Bird's-eye overview**: Switch to Overview mode to list packages/classes for any branch.
+- **Editable quantities**: Toggle Editable mode to add, rename, or remove quantities from the selected class card.
+- **Export**: Save the current graph as JSON or a PDF (PNG-backed) snapshot.
 
 ---
 
@@ -78,6 +83,8 @@ What it does:
 
 Stop both with **Ctrl+C**. Override ports via `API_PORT` / `WEB_PORT` env vars.
 
+Branch-specific render (no diff): set **Package branch** to load `/graph` for a chosen branch instead of the working tree.
+
 Sanity checks (optional, while `./dev.sh` is running):
 ```bash
 curl 'http://127.0.0.1:5179/roots?package=nomad_simulations.schema_packages.model_method'
@@ -95,27 +102,32 @@ curl 'http://127.0.0.1:5179/git/branches'
 4. **Build graph**: Render UML cards and composition edges.
 5. **Doc panel**: Click a class → see its docstring + list of quantities; click a quantity to view its docstring.
 6. **Under the hood panel**: Click a class → see which normalizers and module-level helpers are associated with that section.
-7. **Compare branches**: Choose **Base** and **Head** → **Compare** to see a visual diff.
+7. **Editable mode** (Doc panel): Toggle **Editable mode**, then add/rename/remove quantities on the selected class (supported dtypes are validated server-side).
+8. **Compare branches**: Choose **Base** and **Head** → **Compare** to see a visual diff.
+9. **Export**: Download the current graph as **JSON** or a **PDF** snapshot from the sidebar.
 
 Legend:
-- 🟩 **Added** (green border / edges)  
-- 🟨 **Changed** (amber border)  
+- 🟩 **Added** (green border / edges)
+- 🟨 **Changed** (amber border)
 - 🟥 **Removed** (shown in diff banner; removed edges dashed red)
 
 ---
 
 ## ⚙️ Backend Endpoints (summary)
 
-- `GET /roots?package=...` → `{"sections": [...]}`  
-- `GET /schema`  
-  Params: `package, root?, include_quantities?, include_subsections?, allow_cross_module?, base_namespace?`  
+- `GET /roots?package=...` → `{\"sections\": [...]}`
+- `GET /schema`
+  Params: `package, root?, include_quantities?, include_subsections?, allow_cross_module?, base_namespace?`
   Returns: `{ package, root, nodes, edges }` where:
-  - `nodes[*].kind ∈ {"section","quantity"}`
+  - `nodes[*].kind ∈ {\"section\",\"quantity\"}`
   - `nodes[*].doc` is populated for **both sections and quantities**
-- `GET /git/branches` → `{"branches":[...], "active": "...", "head": "SHA"}`  
+- `POST /graph` → build a graph from a specific branch/worktree
+- `GET /git/branches` → `{\"branches\":[...], \"active\": \"...\", \"head\": \"SHA\"}`
 - `POST /graph/diff` → `{ base:{branch,sha,graph}, head:{...}, diff:{nodes:{added,removed,changed}, edges:{added,removed}} }`
+- `POST /schema/custom-quantity` → inject a validated quantity onto a class (used by Editable mode)
+- `GET /usage` → list normalize methods / helper functions for a given section class
 
-> Quantity docstrings are embedded directly in `/schema`.  
+> Quantity docstrings are embedded directly in `/schema`.
 > The builder that does this is `extractor/graph_builder.py`.
 
 ---
@@ -126,9 +138,10 @@ Legend:
   - Serializes sections and quantities with robust doc extraction (`description`, `m_def.description`, `__doc__`).
   - Quantities are **not rendered as separate boxes** in the canvas. They are folded into the class card and listed in the Doc Panel.
 - **Frontend**
-  - `web/src/GraphView.tsx`: builds Cytoscape graph (sections + composition edges), wires selection to the store.
-  - `web/src/components/DocPanel.tsx`: shows class/quantity docs; lists quantities with dtype/shape/card.
-  - `web/src/components/UnderTheHoodPanel.tsx`: for the selected class, calls /usage on API base and renders the normalization list.
+  - `web/src/GraphView.tsx`: builds Cytoscape graph (sections + composition edges), wires selection to the store, supports diff overlays and export hook.
+  - `web/src/components/DocPanel.tsx`: shows class/quantity docs; lists quantities with dtype/shape/card; inline actions for editable mode.
+  - `web/src/components/UnderTheHoodPanel.tsx`: for the selected class, calls `/usage` on API base and renders the normalization list.
+  - `web/src/components/AddQuantityForm.tsx` and `web/src/components/QuantityEditPanel.tsx`: UI for adding/renaming/removing quantities.
   - `web/src/store/selection.ts`: Zustand store for selected node.
 - **ELK Layout**: layered, right-directed; label size is included in node dimensions.
 
@@ -160,16 +173,16 @@ These are temporary and should **not** be committed.
 
 ## 🧪 Example
 
-Package: `nomad_simulations.schema_packages.model_method`  
-Root: `ModelMethod`  
-- Toggle **Quantities** and **Subsections** as needed.  
+Package: `nomad_simulations.schema_packages.model_method`
+Root: `ModelMethod`
+- Toggle **Quantities** and **Subsections** as needed.
 - Compare `develop` → `sprint-dft-qchem` to see DFT/solvation updates reflected in UML and doc panel.
 
 ---
 
 ## 👩‍💻 Author
 
-**Dr. Esma Birsen Boydaş**  
+**Dr. Esma Birsen Boydaş**
 NOMAD Laboratory (FAIRmat), Humboldt-Universität zu Berlin
 
 > Work in progress — scope and UI may evolve.

--- a/REPO_GUIDE.md
+++ b/REPO_GUIDE.md
@@ -6,9 +6,9 @@ A structured overview of the repository for developers to navigate, understand, 
 
 ## 0) TL;DR
 
-**Purpose:** Visualize NOMAD-compatible schemas (defaults to `nomad-simulations`) as UML diagrams, inspect docstrings and normalization helpers, and compare schema changes across Git branches.
+**Purpose:** Visualize NOMAD-compatible schemas (defaults to `nomad-simulations`) as UML diagrams, inspect docstrings and normalization helpers, edit quantities inline, and compare schema changes across Git branches.
 
-**Frontend:** React + TypeScript + Cytoscape + ELK  
+**Frontend:** React + TypeScript + Cytoscape + ELK
 **Backend:** FastAPI + GitPython
 
 **Main directories:**
@@ -18,13 +18,15 @@ A structured overview of the repository for developers to navigate, understand, 
 - `api/_data/` — auto-generated bare mirror + worktrees (gitignored)
 
 **Key endpoints:**
-- `GET /roots` — list section roots for a package  
-- `GET /schema` — build a graph (single branch)  
-- `GET /overview` — bird’s-eye list of packages and top-level classes at a branch  
-- `GET /git/branches` — list local branches of the repo  
-- `GET /git/packages` — list Python modules under a base package  
-- `POST /graph/diff` — compare two branches and return a diff  
-- `GET /usage` — list normalize methods / helper functions for a given section class  
+- `GET /roots` — list section roots for a package
+- `GET /schema` — build a graph from the working tree (single branch)
+- `POST /graph` — build a graph from a specific branch/worktree (single branch)
+- `POST /graph/diff` — compare two branches and return a diff
+- `POST /schema/custom-quantity` — inject a validated quantity onto a class (used by editable mode)
+- `GET /overview` — bird’s-eye list of packages and top-level classes at a branch
+- `GET /git/branches` — list local branches of the repo
+- `GET /git/packages` — list Python modules under a base package
+- `GET /usage` — list normalize methods / helper functions for a given section class
 
 **Environment variables (one of):**
 ~~~bash
@@ -41,9 +43,12 @@ export SCHEMA_UML_PACKAGE=my_schema_root.module
 
 **UX highlights:**
 - UML cards show **sections**; **quantities** appear as attributes inside the card (not separate nodes).
-- Right **Doc Panel** shows the **class docstring** and a **clickable list of quantities**; clicking a quantity shows its docstring.  
-- Right **Under-the-hood Panel** shows **normalization methods and helper functions** that act on the selected section (based on `/usage`).  
-- Branch diff highlights: 🟩 Added, 🟨 Changed, 🟥 Removed (edges dashed red).
+- Right **Doc Panel** shows the **class docstring** and a **clickable list of quantities**; clicking a quantity shows its docstring.
+- Right **Under-the-hood Panel** shows **normalization methods and helper functions** that act on the selected section (based on `/usage`).
+- **Editable mode**: add, rename, or remove quantities on the selected class; dtype is validated against a supported allowlist.
+- **Bird’s-eye overview** renders packages/classes for a branch without building the full graph.
+- **Exports**: download the current graph JSON or a PDF snapshot.
+- Branch diff highlights: 🟩 Added, 🟨 Changed, 🟥 Removed (edges dashed red; quantity deltas are included).
 
 ---
 
@@ -52,8 +57,8 @@ export SCHEMA_UML_PACKAGE=my_schema_root.module
 ~~~text
 schema-uml/
 ├─ api/                         # FastAPI backend
-│  ├─ main.py                   # App entry, CORS, /roots, /schema, /overview, /usage
-│  ├─ routes_git.py             # /git/branches, /git/packages and /graph/diff
+│  ├─ main.py                   # App entry, CORS, /roots, /schema, /overview, /usage, /schema/custom-quantity
+│  ├─ routes_git.py             # /git/branches, /git/packages, /graph, /graph/diff
 │  ├─ graph_runner.py           # Runs extractor in a worktree subprocess
 │  ├─ git_utils.py              # Bare mirror & worktree management
 │  ├─ diff.py                   # Graph comparison logic
@@ -159,9 +164,10 @@ Example (shortened):
 
 **Frontend rendering policy**
 
-- Added sections → green border (`.diff-added`)  
-- Changed sections → amber border (`.diff-changed`)  
+- Added sections → green border (`.diff-added`)
+- Changed sections → amber border (`.diff-changed`)
 - Removed sections/edges → shown in the diff banner/summary (removed edges dashed red)
+- Quantity changes are represented as `kind="quantity"` entries within the same `diff.nodes` structure; `nodes.changed` may carry `before`/`after` payloads for quantity metadata.
 
 ### 2.3 Usage JSON (`GET /usage` → used by Under-the-hood panel)
 
@@ -186,8 +192,8 @@ Example (shortened):
 
 **Notes**
 
-- Request: `GET /usage?section_id=<fully-qualified-section-class-name>`  
-  Example: `section_id=nomad_simulations.schema_packages.model_method.DFT`  
+- Request: `GET /usage?section_id=<fully-qualified-section-class-name>`
+  Example: `section_id=nomad_simulations.schema_packages.model_method.DFT`
 - Response elements:
   - `kind`: `"normalize_method"` or `"normalize_function"` (later also `"utility_function"`).  
   - `qualname`: fully-qualified Python name of the callable.  
@@ -197,49 +203,74 @@ Example (shortened):
 
 The frontend shows these entries as a list under **Under the hood** for the currently selected section.
 
+### 2.4 Custom quantity request (`POST /schema/custom-quantity`)
+
+~~~json
+{
+  "package": "nomad_simulations.schema_packages.model_method",
+  "class_name": "ModelMethod",
+  "quantity_name": "my_quantity",
+  "dtype": "float",
+  "docstring": "Optional docstring here"
+}
+~~~
+
+**Notes**
+
+- Supported dtypes are validated server-side (`SUPPORTED_CUSTOM_DTYPES` in `api/main.py`).
+- The endpoint rebuilds the graph once, injects the quantity, and returns the updated graph payload used by editable mode in the UI.
+
 ---
 
 ## 3) Backend Flow
 
-1. **`GET /git/branches`**  
-   - Opens repo from `$NOMAD_SIM_REPO` or `$GIT_REPO_DIR` (falls back to current working dir, searching parents).  
+1. **`GET /git/branches`**
+   - Opens repo from `$NOMAD_SIM_REPO` or `$GIT_REPO_DIR` (falls back to current working dir, searching parents).
    - Returns local branch names plus active and HEAD SHA.
 
-2. **`GET /git/packages`**  
-   - Inspects the repo at a given branch.  
-   - Returns importable Python packages under a given base (e.g. `nomad_simulations.schema_packages`).  
+2. **`GET /git/packages`**
+   - Inspects the repo at a given branch.
+   - Returns importable Python packages under a given base (e.g. `nomad_simulations.schema_packages`).
    - Used for the “Choose from develop” dropdown.
 
-3. **`GET /overview`**  
-   - Exports the subtree for a given branch and base package (handles `src/` layout).  
-   - Walks packages under the base and collects top-level class names.  
+3. **`GET /overview`**
+   - Exports the subtree for a given branch and base package (handles `src/` layout).
+   - Walks packages under the base and collects top-level class names.
    - Frontend uses this to render a bird’s-eye `OverviewGrid` of packages vs. classes.
 
-4. **`POST /graph/diff`**  
-   - Creates two worktrees for `{base, head}` (under `api/_data/…`).  
-   - Runs the extractor in each worktree via `graph_runner.py`.  
-   - Computes node/edge deltas in `diff.py`.  
+4. **`POST /graph`**
+   - Materializes a worktree for a requested branch and builds the graph there (single-branch render without diff).
+   - Used when the UI sets **Package branch** to a specific branch.
+
+5. **`POST /graph/diff`**
+   - Creates two worktrees for `{base, head}` (under `api/_data/…`).
+   - Runs the extractor in each worktree via `graph_runner.py`.
+   - Computes node/edge deltas in `diff.py`.
    - Returns `{ base, head, diff }`.
 
-5. **`GET /schema`**  
-   - Runs extractor once (no diff) for interactive browsing.  
+6. **`GET /schema`**
+   - Runs extractor once from the working tree (no diff) for interactive browsing.
    - Options control whether quantities and subsections are included and whether cross-module traversal is allowed.
 
-6. **`GET /usage`**  
-   - Resolves a section class from its fully-qualified name.  
+7. **`POST /schema/custom-quantity`**
+   - Rebuilds the graph for the active package/root, validates the requested dtype, and injects a synthetic quantity node/edge.
+   - Returns the updated graph used by editable mode.
+
+8. **`GET /usage`**
+   - Resolves a section class from its fully-qualified name.
    - Uses `extractor/usage_index.py` to:
-     - Detect a `normalize(...)` method on the class itself.  
-     - Detect module-level helper functions whose names look like normalizers for this class (e.g. `normalize_dft`, `normalize_xc_component`).  
+     - Detect a `normalize(...)` method on the class itself.
+     - Detect module-level helper functions whose names look like normalizers for this class (e.g. `normalize_dft`, `normalize_xc_component`).
    - Returns a small JSON list of `UsageEntry` objects for the selected section.
 
 **Key files**
 
-- `api/main.py` — FastAPI app; `/health`, `/roots`, `/schema`, `/overview`, `/usage`, mounts Git router.  
-- `api/routes_git.py` — `/git/branches`, `/git/packages`, `/graph/diff`.  
-- `api/git_utils.py` — bare clone + worktree management.  
-- `api/graph_runner.py` — subprocess wrapper to call extractor within a worktree.  
-- `api/diff.py` — graph indexing and set diffs.  
-- `extractor/graph_builder.py` — embeds docstrings and source info for sections and quantities.  
+- `api/main.py` — FastAPI app; `/health`, `/roots`, `/schema`, `/schema/custom-quantity`, `/overview`, `/usage`, mounts Git router.
+- `api/routes_git.py` — `/git/branches`, `/git/packages`, `/graph`, `/graph/diff`.
+- `api/git_utils.py` — bare clone + worktree management.
+- `api/graph_runner.py` — subprocess wrapper to call extractor within a worktree.
+- `api/diff.py` — graph indexing and set diffs.
+- `extractor/graph_builder.py` — embeds docstrings and source info for sections and quantities.
 - `extractor/usage_index.py` — introspects normalize methods and helpers; exposes `get_usage_for_section`.
 
 ---
@@ -247,31 +278,35 @@ The frontend shows these entries as a list under **Under the hood** for the curr
 ## 4) Frontend Flow
 
 - **`App.tsx`**
-  - Sidebar controls: API base, package, roots, toggles (quantities / subsections / UML), cross-module, base namespace.  
-  - **Build graph:** calls `/schema` with current filters and renders it in `GraphView`.  
-  - **Compare branches:** calls `/graph/diff` and renders the head graph with diff highlights and a banner.  
-  - **Bird’s-eye view:** calls `/overview` and renders an `OverviewGrid` of packages/classes.  
+  - Sidebar controls: API base, package, package branch (uses `/graph`), roots, toggles (quantities / subsections / UML), cross-module, base namespace, theme.
+  - **Build graph:** calls `/schema` (working tree) or `/graph` (specific branch) with current filters and renders it in `GraphView`.
+  - **Compare branches:** calls `/graph/diff` and renders the head graph with diff highlights and a banner.
+  - **Bird’s-eye view:** calls `/overview` and renders an `OverviewGrid` of packages/classes.
+  - **Exports:** JSON download and PDF snapshot (via `GraphView` export handle).
   - Right column:
-    - Top: `DocPanel` (schema docs + quantities).  
+    - Top: `DocPanel` (schema docs + quantities, includes inline edit/remove hooks).
     - Bottom: `UnderTheHoodPanel` (normalize/helpers list; needs `apiBase`).
+  - **Editable mode:** toggles whether quantity add/edit/remove actions are enabled; uses `/schema/custom-quantity` for adds and client-side updates for rename/delete.
 
 - **`GraphView.tsx`**
-  - Renders sections as UML cards using Cytoscape + ELK.  
-  - Folds quantity metadata into each section’s card label (attributes) and into a `quantitiesByOwner` map for the Doc Panel.  
+  - Renders sections as UML cards using Cytoscape + ELK.
+  - Folds quantity metadata into each section’s card label (attributes) and into a `quantitiesByOwner` map for the Doc Panel.
   - On node tap:
     - Builds a `Selected` object with:
-      - `id = fully-qualified section name`.  
-      - `kind = "class"`.  
-      - `name`, `doc`, `path`, `line`.  
-      - `quantities` for that section.  
-    - Calls `useSelection.getState().setSelected(...)`.  
+      - `id = fully-qualified section name`.
+      - `kind = "class"`.
+      - `name`, `doc`, `path`, `line`.
+      - `quantities` for that section.
+    - Calls `useSelection.getState().setSelected(...)`.
   - Styles: composition edges (diamonds), diff classes (colored outlines), removed edges dashed red.
+  - Exposes `toPng()` via `GraphExportHandle` for PDF export in the sidebar.
 
 - **`components/DocPanel.tsx`**
-  - Reads `selected` from `useSelection`.  
+  - Reads `selected` from `useSelection`.
   - For a selected class:
-    - Shows class name + docstring.  
-    - Lists quantities (name + dtype/shape/card); clicking a quantity displays its docstring.  
+    - Shows class name + docstring.
+    - Lists quantities (name + dtype/shape/card); clicking a quantity displays its docstring.
+    - Provides inline edit/remove controls when editable mode is on.
   - For a selected quantity:
     - Shows that quantity’s docstring and type info.
 
@@ -286,12 +321,15 @@ The frontend shows these entries as a list under **Under the hood** for the curr
     - Shows `short_name`, module, and a short doc summary for each entry.  
   - If nothing or a quantity is selected: shows a placeholder.
 
+- **`components/AddQuantityForm.tsx` & `components/QuantityEditPanel.tsx`**
+  - Form helpers for editable mode (add/rename/remove quantities with validation messaging).
+
 - **`store/selection.ts`**
   - Zustand store with:
-    - `selected: Selected | null`  
-    - `setSelected(s: Selected | null)`  
+    - `selected: Selected | null`
+    - `setSelected(s: Selected | null)`
   - `Selected` holds:
-    - `id`, `kind`, `name`, `doc`, `path`, `line`  
+    - `id`, `kind`, `name`, `doc`, `path`, `line`
     - optional `quantities` (for class nodes).
 
 **Performance tips**

--- a/web/README.md
+++ b/web/README.md
@@ -1,73 +1,46 @@
-# React + TypeScript + Vite
+# Schema UML — Frontend (React + Vite)
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Interactive UML-style viewer for NOMAD schema packages. The UI consumes the FastAPI backend at `http://localhost:5179` and renders section graphs with Cytoscape + ELK.
 
-Currently, two official plugins are available:
+## Quick start
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) (or [oxc](https://oxc.rs) when used in [rolldown-vite](https://vite.dev/guide/rolldown)) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
-
-## React Compiler
-
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+cd web
+npm install
+npm run dev -- --host 0.0.0.0 --port 5173
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+The repo root provides `./dev.sh` to start both backend (**5179**) and frontend (**5173**) together after verifying environment variables.
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+## Environment defaults
 
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
-```
+These Vite env vars (see `App.tsx`) control the initial workspace:
+
+- `VITE_DEFAULT_PACKAGE` — fallback module (defaults to `nomad_simulations.schema_packages.model_method`).
+- `VITE_DEFAULT_NAMESPACE` — comma-separated base namespaces for package discovery (`nomad_simulations.schema_packages` by default).
+- `VITE_DEFAULT_ROOT` — default root section (`ModelMethod`).
+- `VITE_DEFAULT_BRANCH` — default branch for overview/package discovery (`develop`).
+
+## Notable UI features
+
+- Diagram builder for the working tree or a selected branch (`/schema` vs `/graph`).
+- Branch comparison banner using `/graph/diff`.
+- Overview mode listing packages/classes by branch.
+- Editable mode to add/rename/remove quantities (uses `/schema/custom-quantity` for adds; client-side updates for edits/deletes).
+- Doc panel + under-the-hood panel for docstrings and normalization helpers.
+- Export buttons for JSON and PDF (PNG-backed via `GraphView` `toPng`).
+- Theme toggle (dark/light) and namespace / cross-module filters.
+
+## Key files
+
+- `src/App.tsx` — sidebar controls, API calls, diff handling, overview toggle, export + editable mode wiring.
+- `src/GraphView.tsx` — Cytoscape renderer with ELK layout, diff overlays, export handle.
+- `src/components/DocPanel.tsx` — class/quantity docs with inline edit/remove when editable.
+- `src/components/OverviewGrid.tsx` — bird’s-eye packages/classes table.
+- `src/components/UnderTheHoodPanel.tsx` — normalize/helper list from `/usage`.
+- `src/components/AddQuantityForm.tsx`, `src/components/QuantityEditPanel.tsx` — quantity add/edit/remove UI.
+- `src/store/selection.ts` — Zustand selection store.
+
+## Testing & linting
+
+This package relies on Vite defaults. Add your preferred test runner or linter as needed; `npm run build` will validate TypeScript + Vite configuration.


### PR DESCRIPTION
## Summary
- Refresh the root README with current features such as overview mode, editable quantities, exports, and branch-specific graph loads.
- Expand REPO_GUIDE to document new endpoints, custom-quantity requests, and updated backend/frontend flows.
- Replace the web README with project-specific setup steps and UI highlights for the React frontend.

## Testing
- Not run (documentation changes only).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693036a1e2108320936700783031878c)