### PR TITLE
Pin Pydantic v2 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,9 @@ Legend:
 - **Vite overlay / missing deps**
   - Install: `npm i zustand cytoscape cytoscape-elk elkjs` (and `react-markdown` if you render markdown docs).
   - Clear cache: `rm -rf web/node_modules web/node_modules/.vite && npm i`.
+- **Pydantic import error (`model_validator`)**
+  - The backend relies on **Pydantic v2** (`pydantic>=2,<3`).
+  - If you see `ImportError: cannot import name 'model_validator'`, an older global install may be shadowing your environment; reinstall requirements inside a clean virtualenv/conda env to pick up v2.
 
 ---
 

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,6 +1,6 @@
-fastapi
+fastapi>=0.110
 uvicorn
-pydantic
+pydantic>=2,<3
 networkx
 gitpython
 orjson


### PR DESCRIPTION
## Summary
- pin FastAPI and Pydantic to versions that require Pydantic v2 to avoid model_validator import errors
- document the troubleshooting step for environments that still load Pydantic v1

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693041e00d608320b8fe47e69e9648fa)