### PR TITLE
Add resizable panels and root navigation shortcuts

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -141,6 +141,11 @@ export default function App() {
   }, [clampDocWidth, docPanelWidth]);
 
   useEffect(() => {
+    if (!graphHandle) return;
+    graphHandle.refit();
+  }, [graphHandle, sidebarWidth, docPanelWidth]);
+
+  useEffect(() => {
     setDocPanelWidth((w) => clampDocWidth(w));
   }, [clampDocWidth]);
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import axios from "axios";
 import GraphView, { type GraphExportHandle } from "./GraphView";
 import DocPanel from "./components/DocPanel";
@@ -67,6 +67,19 @@ export default function App() {
     return initial;
   });
 
+  const appShellRef = useRef<HTMLElement | null>(null);
+  const workspaceRef = useRef<HTMLDivElement | null>(null);
+  const [sidebarWidth, setSidebarWidth] = useState<number>(() => {
+    if (typeof window === "undefined") return 360;
+    const stored = Number.parseInt(window.localStorage.getItem("schema-uml-left-width") || "", 10);
+    return Number.isFinite(stored) ? stored : 360;
+  });
+  const [docPanelWidth, setDocPanelWidth] = useState<number>(() => {
+    if (typeof window === "undefined") return 380;
+    const stored = Number.parseInt(window.localStorage.getItem("schema-uml-doc-width") || "", 10);
+    return Number.isFinite(stored) ? stored : 380;
+  });
+
   // branch diff state
   const [branches, setBranches] = useState<string[]>([]);
   const [baseBranch, setBaseBranch] = useState<string>("");
@@ -80,7 +93,7 @@ export default function App() {
   const [addErr, setAddErr] = useState<string | null>(null);
   const [quantityActionErr, setQuantityActionErr] = useState<string | null>(null);
 
-  const [exportHandle, setExportHandle] = useState<GraphExportHandle | null>(null);
+  const [graphHandle, setGraphHandle] = useState<GraphExportHandle | null>(null);
 
   const { selected, setSelected } = useSelection();
 
@@ -96,6 +109,65 @@ export default function App() {
     const parts = namespace.split(",").map((p) => p.trim()).filter(Boolean);
     return parts.length > 0 ? parts.join(",") : DEFAULT_NAMESPACE;
   }, [namespace]);
+
+  const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
+
+  const setSidebarWidthClamped = useCallback(
+    (value: number) => setSidebarWidth(clamp(value, 260, 520)),
+    []
+  );
+  const setDocPanelWidthClamped = useCallback(
+    (value: number) => setDocPanelWidth(clamp(value, 260, 640)),
+    []
+  );
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem("schema-uml-left-width", String(clamp(sidebarWidth, 260, 520)));
+  }, [sidebarWidth]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem("schema-uml-doc-width", String(clamp(docPanelWidth, 260, 640)));
+  }, [docPanelWidth]);
+
+  const startSidebarResize = (e: React.MouseEvent) => {
+    e.preventDefault();
+    const rect = appShellRef.current?.getBoundingClientRect();
+    const offsetLeft = rect?.left ?? 0;
+
+    const onMove = (evt: MouseEvent) => {
+      const next = evt.clientX - offsetLeft;
+      setSidebarWidthClamped(next);
+    };
+
+    const stop = () => {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", stop);
+    };
+
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", stop);
+  };
+
+  const startDocResize = (e: React.MouseEvent) => {
+    e.preventDefault();
+
+    const onMove = (evt: MouseEvent) => {
+      const rect = workspaceRef.current?.getBoundingClientRect();
+      if (!rect) return;
+      const next = rect.right - evt.clientX;
+      setDocPanelWidthClamped(next);
+    };
+
+    const stop = () => {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", stop);
+    };
+
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", stop);
+  };
 
   // roots for selected package
   const loadRoots = async () => {
@@ -123,7 +195,7 @@ export default function App() {
     setQuantityActionErr(null);
     setLoading(true);
     setDiffData(null);
-    setExportHandle(null);
+    setGraphHandle(null);
     try {
       if (branchToUse) {
         const r = await api.post(
@@ -207,7 +279,7 @@ export default function App() {
     setQuantityActionErr(null);
     setDiffLoading(true);
     setGraph(null); // switch to diff mode
-    setExportHandle(null);
+    setGraphHandle(null);
     try {
       const r = await api.post(
         "/graph/diff",
@@ -323,6 +395,38 @@ export default function App() {
           : null;
 
   const currentGraph = diffData ? diffData.head?.graph ?? null : graph;
+
+  const focusRootSection = useCallback(() => {
+    const targetRoot = currentGraph?.root || root;
+    if (!targetRoot) return;
+
+    const handled = graphHandle?.focusNode(targetRoot);
+    if (handled) return;
+
+    const fallbackNode = currentGraph?.nodes?.find?.((n: any) => {
+      const label = (n as any).label || (n as any).rawName;
+      return n.id === targetRoot || label === targetRoot;
+    }) as any;
+
+    if (fallbackNode) {
+      setSelected({
+        id: fallbackNode.id,
+        kind: "class",
+        name: fallbackNode.label || fallbackNode.id,
+        doc: fallbackNode.doc || "",
+        path: fallbackNode.path || "",
+        line: typeof fallbackNode.line === "number" ? fallbackNode.line : undefined,
+        fqid:
+          fallbackNode.module && (fallbackNode.label || fallbackNode.id)
+            ? `${fallbackNode.module}.${fallbackNode.label || fallbackNode.id}`
+            : fallbackNode.id,
+      });
+    }
+  }, [currentGraph, graphHandle, root, setSelected]);
+
+  useEffect(() => {
+    focusRootSection();
+  }, [focusRootSection]);
 
   const handleOverviewClassSelect = (pkgName: string, className: string) => {
     setMode("graph");
@@ -443,9 +547,9 @@ export default function App() {
   };
 
   const exportPdf = () => {
-    if (!currentGraph || !exportHandle) return;
+    if (!currentGraph || !graphHandle) return;
 
-    const png = exportHandle.toPng();
+    const png = graphHandle.toPng();
     if (!png) return;
 
     const pdf = new jsPDF({ orientation: "landscape", unit: "pt", format: "a4" });
@@ -464,7 +568,11 @@ export default function App() {
   };
 
   return (
-    <main className="app-shell">
+    <main
+      className="app-shell"
+      ref={appShellRef}
+      style={{ gridTemplateColumns: `${sidebarWidth}px 10px 1fr` }}
+    >
       <aside className="sidebar">
         <div className="brand-card">
           <p className="eyebrow">Schema explorer</p>
@@ -649,8 +757,8 @@ export default function App() {
                   <button
                     className="btn secondary"
                     onClick={exportPdf}
-                    disabled={!exportHandle}
-                    title={exportHandle ? "Download current diagram as PDF" : "Build a graph first"}
+                    disabled={!graphHandle}
+                    title={graphHandle ? "Download current diagram as PDF" : "Build a graph first"}
                   >
                     Export PDF
                   </button>
@@ -712,9 +820,20 @@ export default function App() {
           </div>
         </CollapsibleSection>
       </aside>
+        <div
+          className="resizer"
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="Resize sidebar"
+          onMouseDown={startSidebarResize}
+        />
 
       {/* Main workspace: Graph + Doc Panel side-by-side */}
-      <div className="workspace">
+      <div
+        className="workspace"
+        ref={workspaceRef}
+        style={{ gridTemplateColumns: `1fr 10px ${docPanelWidth}px` }}
+      >
         {/* Left: graph area */}
         <div
           style={{
@@ -741,7 +860,10 @@ export default function App() {
                   Base: {diffData.base.branch} ({diffData.base.sha.slice(0, 7)}) → Head: {diffData.head.branch}
                   ({diffData.head.sha.slice(0, 7)})
                 </div>
-                <div className="row" style={{ gap: 10 }}>
+                <div className="row" style={{ gap: 10, alignItems: "center" }}>
+                  <button className="btn secondary" type="button" onClick={focusRootSection}>
+                    Go to root
+                  </button>
                   <span className="pill">🟩 Added</span>
                   <span className="pill" style={{ background: "rgba(234, 179, 8, 0.18)", color: "#fef9c3" }}>
                     🟨 Changed
@@ -755,11 +877,22 @@ export default function App() {
                 nodes={diffData.head.graph.nodes}
                 edges={diffData.head.graph.edges}
                 diff={diffData.diff}
-                onReady={setExportHandle}
+                onReady={setGraphHandle}
               />
             </>
           ) : graph ? (
-            <GraphView nodes={graph.nodes} edges={graph.edges} onReady={setExportHandle} />
+            <>
+              <div className="workspace-toolbar" style={{ justifyContent: "space-between" }}>
+                <div>
+                  Root: <strong>{currentGraph?.root || root}</strong>
+                  {" "}from <strong>{currentGraph?.package || pkg}</strong>
+                </div>
+                <button className="btn secondary" type="button" onClick={focusRootSection}>
+                  Go to root
+                </button>
+              </div>
+              <GraphView nodes={graph.nodes} edges={graph.edges} onReady={setGraphHandle} />
+            </>
           ) : (
             <div className="empty-state">
               <div style={{ fontSize: 18, marginBottom: 8 }}>Build a diagram to get started</div>
@@ -767,6 +900,14 @@ export default function App() {
             </div>
           )}
         </div>
+
+        <div
+          className="resizer"
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="Resize documentation panel"
+          onMouseDown={startDocResize}
+        />
 
         {/* Right: Documentation + quantity editing */}
         <div

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -142,7 +142,15 @@ export default function App() {
 
   useEffect(() => {
     if (!graphHandle) return;
+
     graphHandle.refit();
+    const t1 = window.setTimeout(() => graphHandle.refit(), 120);
+    const t2 = window.setTimeout(() => graphHandle.refit(), 360);
+
+    return () => {
+      window.clearTimeout(t1);
+      window.clearTimeout(t2);
+    };
   }, [graphHandle, sidebarWidth, docPanelWidth]);
 
   useEffect(() => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -111,14 +111,23 @@ export default function App() {
   }, [namespace]);
 
   const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
+  const clampDocWidth = useCallback((value: number) => {
+    const workspaceWidth = workspaceRef.current?.getBoundingClientRect()?.width ?? 0;
+    const minGraphWidth = 380;
+    const maxByViewport = workspaceWidth
+      ? Math.max(260, workspaceWidth - minGraphWidth - 10)
+      : 640;
+
+    return clamp(value, 260, Math.min(640, maxByViewport));
+  }, []);
 
   const setSidebarWidthClamped = useCallback(
     (value: number) => setSidebarWidth(clamp(value, 260, 520)),
     []
   );
   const setDocPanelWidthClamped = useCallback(
-    (value: number) => setDocPanelWidth(clamp(value, 260, 640)),
-    []
+    (value: number) => setDocPanelWidth(clampDocWidth(value)),
+    [clampDocWidth]
   );
 
   useEffect(() => {
@@ -128,8 +137,22 @@ export default function App() {
 
   useEffect(() => {
     if (typeof window === "undefined") return;
-    window.localStorage.setItem("schema-uml-doc-width", String(clamp(docPanelWidth, 260, 640)));
-  }, [docPanelWidth]);
+    window.localStorage.setItem("schema-uml-doc-width", String(clampDocWidth(docPanelWidth)));
+  }, [clampDocWidth, docPanelWidth]);
+
+  useEffect(() => {
+    setDocPanelWidth((w) => clampDocWidth(w));
+  }, [clampDocWidth]);
+
+  useEffect(() => {
+    const observer = new ResizeObserver(() => {
+      setDocPanelWidth((w) => clampDocWidth(w));
+    });
+
+    if (workspaceRef.current) observer.observe(workspaceRef.current);
+
+    return () => observer.disconnect();
+  }, [clampDocWidth]);
 
   const startSidebarResize = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -832,7 +855,7 @@ export default function App() {
       <div
         className="workspace"
         ref={workspaceRef}
-        style={{ gridTemplateColumns: `1fr 10px ${docPanelWidth}px` }}
+        style={{ gridTemplateColumns: `minmax(0, 1fr) 10px ${docPanelWidth}px` }}
       >
         {/* Left: graph area */}
         <div

--- a/web/src/GraphView.tsx
+++ b/web/src/GraphView.tsx
@@ -36,6 +36,7 @@ type RawEdge = {
 export type GraphExportHandle = {
   toPng: () => string | null;
   focusNode: (name: string) => boolean;
+  refit: () => void;
 };
 
 type Props = {
@@ -368,6 +369,20 @@ export default function GraphView({ nodes, edges, diff, onReady }: Props) {
       } as any
     });
 
+    let refitTimeout: number | null = null;
+
+    const refitToContent = () => {
+      cy.resize();
+      cy.fit(undefined, 32);
+    };
+
+    const scheduleRefit = () => {
+      refitToContent();
+      requestAnimationFrame(refitToContent);
+      if (refitTimeout) window.clearTimeout(refitTimeout);
+      refitTimeout = window.setTimeout(refitToContent, 140);
+    };
+
     let handlePublished = false;
 
     const publishHandle = () => {
@@ -381,21 +396,8 @@ export default function GraphView({ nodes, edges, diff, onReady }: Props) {
             bg: "#ffffff"
           }) ?? null,
         focusNode,
+        refit: () => scheduleRefit(),
       });
-    };
-
-    let refitTimeout: number | null = null;
-
-    const refitToContent = () => {
-      cy.resize();
-      cy.fit(undefined, 32);
-    };
-
-    const scheduleRefit = () => {
-      refitToContent();
-      requestAnimationFrame(refitToContent);
-      if (refitTimeout) window.clearTimeout(refitTimeout);
-      refitTimeout = window.setTimeout(refitToContent, 140);
     };
 
     cy.one("layoutstop", () => {

--- a/web/src/GraphView.tsx
+++ b/web/src/GraphView.tsx
@@ -368,12 +368,31 @@ export default function GraphView({ nodes, edges, diff, onReady }: Props) {
       } as any
     });
 
+    let handlePublished = false;
+
+    const publishHandle = () => {
+      if (handlePublished) return;
+      handlePublished = true;
+      onReady?.({
+        toPng: () =>
+          cyRef.current?.png({
+            full: true,
+            scale: 2,
+            bg: "#ffffff"
+          }) ?? null,
+        focusNode,
+      });
+    };
+
     const refitToContent = () => {
       cy.resize();
       cy.fit(undefined, 24);
     };
 
-    cy.one("layoutstop", refitToContent);
+    cy.one("layoutstop", () => {
+      refitToContent();
+      publishHandle();
+    });
 
     const resizeObserver = new ResizeObserver(() => refitToContent());
     resizeObserver.observe(containerRef.current);
@@ -439,14 +458,11 @@ export default function GraphView({ nodes, edges, diff, onReady }: Props) {
 
     cyRef.current = cy;
 
-    onReady?.({
-      toPng: () =>
-        cyRef.current?.png({
-          full: true,
-          scale: 2,
-          bg: "#ffffff"
-        }) ?? null,
-      focusNode,
+    cy.ready(() => {
+      // In rare cases ELK may not fire layoutstop (e.g., empty graphs);
+      // ensure the view centers and the handle is published once the core is ready.
+      refitToContent();
+      publishHandle();
     });
 
     // Diff highlights (unchanged)

--- a/web/src/GraphView.tsx
+++ b/web/src/GraphView.tsx
@@ -384,17 +384,26 @@ export default function GraphView({ nodes, edges, diff, onReady }: Props) {
       });
     };
 
+    let refitTimeout: number | null = null;
+
     const refitToContent = () => {
       cy.resize();
-      cy.fit(undefined, 24);
+      cy.fit(undefined, 32);
+    };
+
+    const scheduleRefit = () => {
+      refitToContent();
+      requestAnimationFrame(refitToContent);
+      if (refitTimeout) window.clearTimeout(refitTimeout);
+      refitTimeout = window.setTimeout(refitToContent, 140);
     };
 
     cy.one("layoutstop", () => {
-      refitToContent();
+      scheduleRefit();
       publishHandle();
     });
 
-    const resizeObserver = new ResizeObserver(() => refitToContent());
+    const resizeObserver = new ResizeObserver(() => scheduleRefit());
     resizeObserver.observe(containerRef.current);
 
     const focusNode = (name: string) => {
@@ -461,7 +470,7 @@ export default function GraphView({ nodes, edges, diff, onReady }: Props) {
     cy.ready(() => {
       // In rare cases ELK may not fire layoutstop (e.g., empty graphs);
       // ensure the view centers and the handle is published once the core is ready.
-      refitToContent();
+      scheduleRefit();
       publishHandle();
     });
 
@@ -491,6 +500,7 @@ export default function GraphView({ nodes, edges, diff, onReady }: Props) {
 
     return () => {
       resizeObserver.disconnect();
+      if (refitTimeout) window.clearTimeout(refitTimeout);
       onReady?.(null);
       cyRef.current?.destroy();
     };

--- a/web/src/GraphView.tsx
+++ b/web/src/GraphView.tsx
@@ -368,6 +368,16 @@ export default function GraphView({ nodes, edges, diff, onReady }: Props) {
       } as any
     });
 
+    const refitToContent = () => {
+      cy.resize();
+      cy.fit(undefined, 24);
+    };
+
+    cy.one("layoutstop", refitToContent);
+
+    const resizeObserver = new ResizeObserver(() => refitToContent());
+    resizeObserver.observe(containerRef.current);
+
     const focusNode = (name: string) => {
       const cy = cyRef.current;
       if (!cy) return false;
@@ -464,6 +474,7 @@ export default function GraphView({ nodes, edges, diff, onReady }: Props) {
     }
 
     return () => {
+      resizeObserver.disconnect();
       onReady?.(null);
       cyRef.current?.destroy();
     };

--- a/web/src/GraphView.tsx
+++ b/web/src/GraphView.tsx
@@ -5,7 +5,7 @@ import cytoscapeElk from "cytoscape-elk";
 import type { Core, ElementDefinition } from "cytoscape";
 import { useSelection, type QtyMeta, type QtySnapshot } from "./store/selection";
 
-type QtyDiffState = QtyMeta["diff"] extends { state: infer S } ? S : undefined;
+type QtyDiffState = "added" | "removed" | "changed" | undefined;
 
 cytoscapeElk(cytoscape, elk as any);
 
@@ -35,6 +35,7 @@ type RawEdge = {
 
 export type GraphExportHandle = {
   toPng: () => string | null;
+  focusNode: (name: string) => boolean;
 };
 
 type Props = {
@@ -298,7 +299,7 @@ export default function GraphView({ nodes, edges, diff, onReady }: Props) {
       elements,
       minZoom: 0.2,
       maxZoom: 3.5,
-      wheelSensitivity: 0.2,
+      wheelSensitivity: 0.65,
       style: [
         {
           selector: "node[kind='uml_class']",
@@ -367,9 +368,24 @@ export default function GraphView({ nodes, edges, diff, onReady }: Props) {
       } as any
     });
 
-    // Selection → DocPanel + UnderTheHoodPanel
-    cy.on("tap", "node", (evt) => {
-      const d = evt.target.data();
+    const focusNode = (name: string) => {
+      const cy = cyRef.current;
+      if (!cy) return false;
+
+      const normalized = name.toLowerCase();
+      const target = cy
+        .nodes()
+        .filter((n) => {
+          const id = `${n.id()}`.toLowerCase();
+          const raw = `${n.data("rawName") ?? ""}`.toLowerCase();
+          const label = `${n.data("label") ?? ""}`.toLowerCase();
+          return id === normalized || raw === normalized || label === normalized;
+        })
+        .first();
+
+      if (!target || target.empty()) return false;
+
+      const d = target.data();
       const qList = quantitiesByOwner.get(d.id) || [];
 
       // fully-qualified section name for /usage
@@ -380,8 +396,8 @@ export default function GraphView({ nodes, edges, diff, onReady }: Props) {
           : d.id;
 
       useSelection.getState().setSelected({
-        id: d.id,                    
-        fqid,                       
+        id: d.id,
+        fqid,
         kind: "class",
         name: d.rawName || d.id,
         doc: d.doc || "",
@@ -389,6 +405,22 @@ export default function GraphView({ nodes, edges, diff, onReady }: Props) {
         line: typeof d.line === "number" ? d.line : undefined,
         quantities: qList,
       });
+
+      cy.animate(
+        {
+          center: { eles: target },
+          zoom: Math.min(1.2, cy.maxZoom()),
+        },
+        { duration: 240, easing: "ease-in-out" }
+      );
+
+      target.select();
+      return true;
+    };
+
+    // Selection → DocPanel + UnderTheHoodPanel
+    cy.on("tap", "node", (evt) => {
+      focusNode(evt.target.data("rawName") || evt.target.id());
     });
 
     cy.on("tap", (evt) => {
@@ -403,7 +435,8 @@ export default function GraphView({ nodes, edges, diff, onReady }: Props) {
           full: true,
           scale: 2,
           bg: "#ffffff"
-        }) ?? null
+        }) ?? null,
+      focusNode,
     });
 
     // Diff highlights (unchanged)

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -268,7 +268,7 @@ hr { border:0; border-top:1px solid var(--panel-border); margin:12px 0; }
 
 .workspace {
   display: grid;
-  grid-template-columns: 1fr 10px 380px;
+  grid-template-columns: minmax(0, 1fr) 10px 380px;
   height: 100vh;
   overflow: hidden;
 }

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -84,7 +84,7 @@ html, body, #root {
 
 main {
   display: grid;
-  grid-template-columns: 360px 1fr;
+  grid-template-columns: 360px 10px 1fr;
   height: 100%;
   backdrop-filter: blur(10px);
 }
@@ -268,9 +268,35 @@ hr { border:0; border-top:1px solid var(--panel-border); margin:12px 0; }
 
 .workspace {
   display: grid;
-  grid-template-columns: 1fr 380px;
+  grid-template-columns: 1fr 10px 380px;
   height: 100vh;
   overflow: hidden;
+}
+
+.resizer {
+  width: 10px;
+  cursor: col-resize;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+}
+
+.resizer::after {
+  content: "";
+  width: 2px;
+  height: 60%;
+  border-radius: 4px;
+  background: var(--panel-border);
+  transition: background 120ms ease, height 120ms ease;
+}
+
+.resizer:hover::after,
+.resizer:active::after,
+.resizer:focus-visible::after {
+  background: var(--accent);
+  height: 76%;
+  box-shadow: 0 0 0 2px var(--input-focus-shadow);
 }
 
 .workspace-toolbar {


### PR DESCRIPTION
## Summary
- allow the main sidebar and documentation panel to be resized with drag handles and persisted widths
- increase graph scroll zoom sensitivity and expose a focus helper for navigation
- add go-to-root controls that auto-focus the module root when diagrams load

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693147a30f3c8320a5c1c5a4d45e8f12)