### PR TITLE
Narrow default base namespace and document optional measurements

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,14 +101,13 @@ curl 'http://127.0.0.1:5179/git/branches'
 ## 🧠 How to Use
 
 1. **Package**: Enter a Python package (e.g. `nomad_simulations.schema_packages.model_method`).
-2. **Load roots**: Fetch available section classes from the package.
-3. **Root section**: Pick one (e.g. `ModelMethod`) or leave empty to load all.
-4. **Build graph**: Render UML cards and composition edges.
-5. **Doc panel**: Click a class → see its docstring + list of quantities; click a quantity to view its docstring.
-6. **Under the hood panel**: Click a class → see which normalizers and module-level helpers are associated with that section.
-7. **Editable mode** (Doc panel): Toggle **Editable mode**, then add/rename/remove quantities on the selected class (supported dtypes are validated server-side).
-8. **Compare branches**: Choose **Base** and **Head** → **Compare** to see a visual diff.
-9. **Export**: Download the current graph as **JSON** or a **PDF** snapshot from the sidebar.
+2. **Root section**: Auto-populated from the package; pick one (e.g. `ModelMethod`) or leave empty to load all.
+3. **Build graph**: Render UML cards and composition edges.
+4. **Doc panel**: Click a class → see its docstring + list of quantities; click a quantity to view its docstring.
+5. **Under the hood panel**: Click a class → see which normalizers and module-level helpers are associated with that section.
+6. **Editable mode** (Doc panel): Toggle **Editable mode**, then add/rename/remove quantities on the selected class (supported dtypes are validated server-side).
+7. **Compare branches**: Choose **Base** and **Head** → **Compare** to see a visual diff.
+8. **Export**: Download the current graph as **JSON** or a **PDF** snapshot from the sidebar.
 
 Legend:
 - 🟩 **Added** (green border / edges)

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ export SCHEMA_UML_REPO=<path-or-URL-to-your-schema-repo>
 # optional: override the default package used in UI helpers
 # export SCHEMA_UML_PACKAGE=my_schema_root.module
 ```
+By default, the viewer scopes to `nomad_simulations.schema_packages`. If you also want
+to browse `nomad_measurements`, set `SCHEMA_UML_BASE_PACKAGE` to include both
+namespaces (e.g. `nomad_simulations.schema_packages,nomad_measurements`) and point
+`NOMAD_MEASURE_REPO` at a local `nomad-measurements` clone.
 Make it persistent by adding the export to `~/.bashrc` or `~/.zshrc`.
 
 ### 4) Run everything with one command

--- a/REPO_GUIDE.md
+++ b/REPO_GUIDE.md
@@ -38,6 +38,10 @@ export GIT_REPO_DIR=/path/to/nomad-simulations
 export SCHEMA_UML_BASE_PACKAGE=my_schema_root
 export SCHEMA_UML_PACKAGE=my_schema_root.module
 ~~~
+Default namespace scope targets `nomad_simulations.schema_packages`. To include
+`nomad_measurements`, set `SCHEMA_UML_BASE_PACKAGE` to both namespaces (comma
+separated) and ensure `NOMAD_MEASURE_REPO` points at a local clone of that
+repository.
 
 **Unified dev command:** `./dev.sh` starts the FastAPI backend (**5179**) and Vite frontend (**5173**), checks for `uvicorn`/`npm`, validates **SCHEMA_UML_REPO / NOMAD_SIM_REPO / GIT_REPO_DIR** points to a local git repo (a subdirectory of a clone is fine), installs frontend deps on first run, and stops both on **Ctrl+C**. Override ports via `API_PORT` / `WEB_PORT`.
 

--- a/api/settings.py
+++ b/api/settings.py
@@ -36,7 +36,8 @@ REPO_SLUG = _repo_slug(SCHEMA_REPO)
 # Default base package/section can be overridden per request or via env vars
 DEFAULT_BASE_PACKAGE = os.getenv(
     "SCHEMA_UML_BASE_PACKAGE",
-    "nomad_simulations.schema_packages,nomad_measurements",
+    # Default to the simulations schema; opt into nomad-measurements via env var
+    "nomad_simulations.schema_packages",
 )
 
 

--- a/extractor/graph_builder.py
+++ b/extractor/graph_builder.py
@@ -227,12 +227,21 @@ def _ref_target_name(dtype_obj) -> Optional[str]:
     def _name_from_target(target: Any) -> Optional[str]:
         cls = _resolve_section_class(target)
         if cls is None:
-            cls = target if inspect.isclass(target) else None
+            cls = target if inspect.isclass(target) else getattr(target, "__class__", None)
         if cls is None:
             return None
-        mod = getattr(cls, "__module__", "")
+
+        # Prefer the section/class name without a long module prefix
         name = getattr(cls, "__name__", None) or getattr(cls, "name", None)
-        return f"{mod}.{name}" if (mod and name) else name
+        if not name:
+            return None
+
+        mod = getattr(cls, "__module__", "")
+        if mod and not mod.startswith("builtins"):
+            mod_short = mod.rsplit(".", 1)[-1]
+            if mod_short and mod_short != name:
+                return f"{mod_short}.{name}"
+        return name
 
     # Common attributes exposed by NOMAD Reference dtypes
     for attr in (
@@ -250,6 +259,22 @@ def _ref_target_name(dtype_obj) -> Optional[str]:
 
 
 def _dtype_from(q) -> Optional[str]:
+    def _friendly_type_label(obj, prefer_class: bool = False) -> Optional[str]:
+        cls = obj if prefer_class else getattr(obj, "__class__", None)
+        if cls is None:
+            return None
+
+        mod = getattr(cls, "__module__", "")
+        name = getattr(cls, "__name__", None)
+        if not name:
+            return None
+
+        if mod and not mod.startswith("builtins"):
+            mod_short = mod.rsplit(".", 1)[-1]
+            if mod_short and mod_short != name:
+                return f"{mod_short}.{name}"
+        return name
+
     for attr in ("dtype", "type"):
         if not hasattr(q, attr):
             continue
@@ -259,19 +284,9 @@ def _dtype_from(q) -> Optional[str]:
             if target:
                 return f"Reference[{target}]"
 
-            # If the object itself is a class, prefer its qualified name
-            if inspect.isclass(dtype_obj):
-                mod = getattr(dtype_obj, "__module__", "")
-                name = getattr(dtype_obj, "__name__", None) or str(dtype_obj)
-                return f"{mod}.{name}" if (mod and name) else name
-
-            # Otherwise use the class name instead of the default repr
-            cls = getattr(dtype_obj, "__class__", None)
-            if cls is not None and cls is not object:
-                mod = getattr(cls, "__module__", "")
-                name = getattr(cls, "__name__", None)
-                if name:
-                    return f"{mod}.{name}" if mod and not mod.startswith("builtins") else name
+            label = _friendly_type_label(dtype_obj, prefer_class=inspect.isclass(dtype_obj))
+            if label:
+                return label
 
             return str(dtype_obj)
         except Exception:

--- a/extractor/graph_builder.py
+++ b/extractor/graph_builder.py
@@ -221,13 +221,61 @@ def _cardinality_from(obj) -> Optional[str]:
     return None
 
 
+def _ref_target_name(dtype_obj) -> Optional[str]:
+    """Best-effort human-friendly target for Reference-like dtypes."""
+
+    def _name_from_target(target: Any) -> Optional[str]:
+        cls = _resolve_section_class(target)
+        if cls is None:
+            cls = target if inspect.isclass(target) else None
+        if cls is None:
+            return None
+        mod = getattr(cls, "__module__", "")
+        name = getattr(cls, "__name__", None) or getattr(cls, "name", None)
+        return f"{mod}.{name}" if (mod and name) else name
+
+    # Common attributes exposed by NOMAD Reference dtypes
+    for attr in (
+        "target_section_def",
+        "target_section_cls",
+        "target",
+        "section_def",
+        "section",
+    ):
+        if hasattr(dtype_obj, attr):
+            name = _name_from_target(getattr(dtype_obj, attr))
+            if name:
+                return name
+    return None
+
+
 def _dtype_from(q) -> Optional[str]:
     for attr in ("dtype", "type"):
-        if hasattr(q, attr):
-            try:
-                return str(getattr(q, attr))
-            except Exception:
-                pass
+        if not hasattr(q, attr):
+            continue
+        try:
+            dtype_obj = getattr(q, attr)
+            target = _ref_target_name(dtype_obj)
+            if target:
+                return f"Reference[{target}]"
+
+            # If the object itself is a class, prefer its qualified name
+            if inspect.isclass(dtype_obj):
+                mod = getattr(dtype_obj, "__module__", "")
+                name = getattr(dtype_obj, "__name__", None) or str(dtype_obj)
+                return f"{mod}.{name}" if (mod and name) else name
+
+            # Otherwise use the class name instead of the default repr
+            cls = getattr(dtype_obj, "__class__", None)
+            if cls is not None and cls is not object:
+                mod = getattr(cls, "__module__", "")
+                name = getattr(cls, "__name__", None)
+                if name:
+                    return f"{mod}.{name}" if mod and not mod.startswith("builtins") else name
+
+            return str(dtype_obj)
+        except Exception:
+            pass
     return None
 
 

--- a/extractor/graph_builder.py
+++ b/extractor/graph_builder.py
@@ -259,22 +259,6 @@ def _ref_target_name(dtype_obj) -> Optional[str]:
 
 
 def _dtype_from(q) -> Optional[str]:
-    def _friendly_type_label(obj, prefer_class: bool = False) -> Optional[str]:
-        cls = obj if prefer_class else getattr(obj, "__class__", None)
-        if cls is None:
-            return None
-
-        mod = getattr(cls, "__module__", "")
-        name = getattr(cls, "__name__", None)
-        if not name:
-            return None
-
-        if mod and not mod.startswith("builtins"):
-            mod_short = mod.rsplit(".", 1)[-1]
-            if mod_short and mod_short != name:
-                return f"{mod_short}.{name}"
-        return name
-
     for attr in ("dtype", "type"):
         if not hasattr(q, attr):
             continue
@@ -283,11 +267,6 @@ def _dtype_from(q) -> Optional[str]:
             target = _ref_target_name(dtype_obj)
             if target:
                 return f"Reference[{target}]"
-
-            label = _friendly_type_label(dtype_obj, prefer_class=inspect.isclass(dtype_obj))
-            if label:
-                return label
-
             return str(dtype_obj)
         except Exception:
             pass

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -622,24 +622,26 @@ export default function App() {
             <span className="tag">{loading || diffLoading ? "Working…" : "Ready"}</span>
             {selectedClassName ? <span className="tag">Selected: {selectedClassName}</span> : null}
           </div>
-        </div>
-
-        <CollapsibleSection title="Appearance" hint="Dark vs light ambience">
-          <div className="toggle-group">
-            <button
-              className={`toggle-chip ${theme === "dark" ? "active" : ""}`}
-              onClick={() => setTheme("dark")}
-            >
-              Dark
-            </button>
-            <button
-              className={`toggle-chip ${theme === "light" ? "active" : ""}`}
-              onClick={() => setTheme("light")}
-            >
-              Light
-            </button>
+          <div style={{ marginTop: 12 }}>
+            <div className="label" style={{ marginBottom: 6 }}>
+              Appearance
+            </div>
+            <div className="toggle-group">
+              <button
+                className={`toggle-chip ${theme === "dark" ? "active" : ""}`}
+                onClick={() => setTheme("dark")}
+              >
+                Dark
+              </button>
+              <button
+                className={`toggle-chip ${theme === "light" ? "active" : ""}`}
+                onClick={() => setTheme("light")}
+              >
+                Light
+              </button>
+            </div>
           </div>
-        </CollapsibleSection>
+        </div>
 
         <CollapsibleSection title="Workspace" hint="Switch modes on the fly">
           <div className="row" style={{ gap: 10 }}>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -941,7 +941,10 @@ export default function App() {
           ) : (
             <div className="empty-state">
               <div style={{ fontSize: 18, marginBottom: 8 }}>Build a diagram to get started</div>
-              <div>Select a package, load roots, pick a root, then “Build graph”; or compare two branches.</div>
+              <div>
+                Select a package (roots load automatically), pick a root, then “Build graph”; or compare two
+                branches.
+              </div>
             </div>
           )}
         </div>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -50,6 +50,7 @@ export default function App() {
 
   const [includeQuantities, setIncludeQuantities] = useState<boolean>(true);
   const [includeSubsections, setIncludeSubsections] = useState<boolean>(true);
+  const [showQuantityMetadata, setShowQuantityMetadata] = useState<boolean>(true);
 
   const [crossModules, setCrossModules] = useState<boolean>(true);
   const [namespace, setNamespace] = useState<string>(DEFAULT_NAMESPACE);
@@ -766,6 +767,14 @@ export default function App() {
               <label style={{ display: "flex", gap: 6, alignItems: "center" }}>
                 <input
                   type="checkbox"
+                  checked={showQuantityMetadata}
+                  onChange={(e) => setShowQuantityMetadata(e.target.checked)}
+                />
+                Show dtypes & shapes
+              </label>
+              <label style={{ display: "flex", gap: 6, alignItems: "center" }}>
+                <input
+                  type="checkbox"
                   checked={includeSubsections}
                   onChange={(e) => setIncludeSubsections(e.target.checked)}
                 />
@@ -913,6 +922,7 @@ export default function App() {
                 nodes={diffData.head.graph.nodes}
                 edges={diffData.head.graph.edges}
                 diff={diffData.diff}
+                showQuantityMetadata={showQuantityMetadata}
                 onReady={setGraphHandle}
               />
             </>
@@ -927,7 +937,12 @@ export default function App() {
                   Go to root
                 </button>
               </div>
-              <GraphView nodes={graph.nodes} edges={graph.edges} onReady={setGraphHandle} />
+              <GraphView
+                nodes={graph.nodes}
+                edges={graph.edges}
+                showQuantityMetadata={showQuantityMetadata}
+                onReady={setGraphHandle}
+              />
             </>
           ) : (
             <div className="empty-state">

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -735,23 +735,17 @@ export default function App() {
               </select>
             </div>
 
-            <div className="row" style={{ justifyContent: "space-between" }}>
-              <div>
-                <label className="label">Root section</label>
-                <select className="select" value={root} onChange={(e) => setRoot(e.target.value)}>
-                  {roots.map((r) => (
-                    <option key={r} value={r}>
-                      {r}
-                    </option>
-                  ))}
-                </select>
-              </div>
-              <div>
-                <label className="label">&nbsp;</label>
-                <button className="btn" onClick={loadRoots}>
-                  Load roots
-                </button>
-                <div className="small">{roots.length ? `${roots.length} sections` : ""}</div>
+            <div>
+              <label className="label">Root section</label>
+              <select className="select" value={root} onChange={(e) => setRoot(e.target.value)}>
+                {roots.map((r) => (
+                  <option key={r} value={r}>
+                    {r}
+                  </option>
+                ))}
+              </select>
+              <div className="small" style={{ marginTop: 4 }}>
+                {roots.length ? `${roots.length} sections` : ""}
               </div>
             </div>
 

--- a/web/src/GraphView.tsx
+++ b/web/src/GraphView.tsx
@@ -50,6 +50,7 @@ type Props = {
     };
   } | null;
   onReady?: (handle: GraphExportHandle | null) => void;
+  showQuantityMetadata?: boolean;
 };
 
 const cleanType = (t?: string | null) => {
@@ -63,7 +64,8 @@ const cleanType = (t?: string | null) => {
 function umlLabel(
   name: string,
   attrs: { name: string; dtype?: string; shape?: string | null; card?: string | null; diff?: QtyDiffState }[],
-  methods: string[]
+  methods: string[],
+  showMetadata: boolean
 ) {
   const MAX_A = 18;
   const MAX_M = 14;
@@ -77,9 +79,9 @@ function umlLabel(
     if (a.diff === "changed") parts.push("🟠 ");
 
     parts.push(a.name);
-    const dt = cleanType(a.dtype);
+    const dt = showMetadata ? cleanType(a.dtype) : "";
     if (dt) parts.push(`: ${dt}`);
-    if (a.shape && a.shape !== "[]") parts.push(` ${a.shape}`);
+    if (showMetadata && a.shape && a.shape !== "[]") parts.push(` ${a.shape}`);
     if (a.card) parts.push(` [${a.card}]`);
     return parts.join("");
   });
@@ -93,7 +95,7 @@ function umlLabel(
   return lines.join("\n");
 }
 
-export default function GraphView({ nodes, edges, diff, onReady }: Props) {
+export default function GraphView({ nodes, edges, diff, onReady, showQuantityMetadata = true }: Props) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const cyRef = useRef<Core | null>(null);
 
@@ -271,7 +273,7 @@ export default function GraphView({ nodes, edges, diff, onReady }: Props) {
       elements.push({
         data: {
           id: secId,
-          label: umlLabel(sec.label, attrs, methods),
+          label: umlLabel(sec.label, attrs, methods, showQuantityMetadata),
           rawName: sec.label,
           kind: "uml_class",
           module: sec.module ?? "",
@@ -506,7 +508,7 @@ export default function GraphView({ nodes, edges, diff, onReady }: Props) {
       onReady?.(null);
       cyRef.current?.destroy();
     };
-  }, [sectionsMap, attrsMap, methodsMap, compEdges, quantitiesByOwner, diff, setSelected, onReady]);
+  }, [sectionsMap, attrsMap, methodsMap, compEdges, quantitiesByOwner, diff, setSelected, onReady, showQuantityMetadata]);
 
   return <div className="graph" ref={containerRef} />;
 }

--- a/web/src/components/UnderTheHoodPanel.tsx
+++ b/web/src/components/UnderTheHoodPanel.tsx
@@ -49,33 +49,33 @@ const UnderTheHoodPanel: React.FC<Props> = ({ apiBase }) => {
 
   return (
     <div className="panel under-the-hood-panel">
-      <h2>Under the hood</h2>
+      <div className="uth-header">
+        <div className="meta-label">Under the hood</div>
+        <div className="hint">Raw schema structure</div>
+      </div>
 
       {!selected || selected.kind !== 'class' ? (
-        <p>Select a section to see normalization and utility functions.</p>
+        <div className="uth-empty">Select a section to see normalization and utility functions.</div>
       ) : (
         <>
-          <h3>{selected.name}</h3>
+          <h3 className="uth-title">{selected.name}</h3>
 
-          {loading && <p>Loading…</p>}
+          {loading && <p className="uth-muted">Loading…</p>}
 
           {!loading && usage && usage.length === 0 && (
-            <p>No normalization or utility functions indexed for this section.</p>
+            <p className="uth-muted">No normalization or utility functions indexed for this section.</p>
           )}
 
           {!loading && usage && usage.length > 0 && (
-            <ul>
+            <ul className="uth-list">
               {usage.map((u) => (
-                <li key={u.qualname} style={{ marginBottom: '0.5rem' }}>
-                  <strong>{kindLabel[u.kind] ?? u.kind}</strong>
-                  <br />
-                  <code>{u.short_name}</code>{' '}
-                  <span style={{ opacity: 0.7 }}>({u.module})</span>
-                  {u.doc && (
-                    <div style={{ fontSize: '0.85rem', marginTop: '0.15rem' }}>
-                      {u.doc}
-                    </div>
-                  )}
+                <li key={u.qualname} className="uth-item">
+                  <div className="uth-kind">{kindLabel[u.kind] ?? u.kind}</div>
+                  <div className="uth-identifier">
+                    <code className="uth-name">{u.short_name}</code>
+                    <span className="uth-module">{u.module}</span>
+                  </div>
+                  {u.doc && <div className="uth-doc">{u.doc}</div>}
                 </li>
               ))}
             </ul>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -418,6 +418,101 @@ hr { border:0; border-top:1px solid var(--panel-border); margin:12px 0; }
   font-weight: 700;
 }
 
+.under-the-hood-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  color: var(--text-primary);
+}
+
+.uth-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.uth-header .hint {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.uth-title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 18px;
+  letter-spacing: 0.01em;
+}
+
+.uth-muted {
+  color: var(--muted);
+  font-size: 13px;
+  margin: 0;
+}
+
+.uth-empty {
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px dashed var(--doc-stroke);
+  background: var(--doc-soft);
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.uth-list {
+  list-style: none;
+  padding: 0;
+  margin: 4px 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.uth-item {
+  border-radius: 12px;
+  border: 1px solid var(--doc-stroke);
+  background: var(--doc-soft);
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.uth-kind {
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--subtitle);
+  font-weight: 700;
+}
+
+.uth-identifier {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.uth-name {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  padding: 4px 8px;
+  border-radius: 8px;
+  background: var(--code-chip-bg);
+  color: var(--code-chip-color);
+}
+
+.uth-module {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.uth-doc {
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--text-primary);
+}
+
 .qty-count {
   font-size: 12px;
   background: var(--surface);


### PR DESCRIPTION
## Summary
- limit the default base namespace to the simulations schema so missing measurement clones no longer break helper endpoints
- document how to opt into nomad-measurements by setting SCHEMA_UML_BASE_PACKAGE and NOMAD_MEASURE_REPO

## Testing
- pytest
- npm run build
- npm run lint *(fails: existing @typescript-eslint/no-explicit-any violations)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69316355e81083209f3f5c38507ae49c)