### PR TITLE
add inheritance toggle, rm unnecessary buttons and texts, adjust md f…

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,6 @@ Back end: **FastAPI** · Front end: **React + Cytoscape + ELK**.
 - **Editable mode**: add, rename, or remove quantities directly in the UI (server validates supported dtypes).
 - **Export**: download the current graph as JSON or a PDF snapshot.
 
-## 🔧 Important note:
-
-Support for `nomad-measurements` is experimental and may behave in unexpected ways.
-
 ---
 
 # Overview
@@ -37,6 +33,7 @@ Support for `nomad-measurements` is experimental and may behave in unexpected wa
 - **Namespace filtering**: Limit traversal to a base namespace; optionally include cross-module links.
 - **Bird's-eye overview**: Switch to Overview mode to list packages/classes for any branch.
 - **Editable quantities**: Toggle Editable mode to add, rename, or remove quantities from the selected class card.
+- **Optional overlays**: Inheritance edges and dtype/shape metadata are opt-in toggles (off by default).
 - **Export**: Save the current graph as JSON or a PDF (PNG-backed) snapshot.
 
 ---
@@ -71,10 +68,9 @@ export SCHEMA_UML_REPO=<path-or-URL-to-your-schema-repo>
 # optional: override the default package used in UI helpers
 # export SCHEMA_UML_PACKAGE=my_schema_root.module
 ```
-By default, the viewer scopes to `nomad_simulations.schema_packages`. If you also want
-to browse `nomad_measurements`, set `SCHEMA_UML_BASE_PACKAGE` to include both
-namespaces (e.g. `nomad_simulations.schema_packages,nomad_measurements`) and point
-`NOMAD_MEASURE_REPO` at a local `nomad-measurements` clone.
+By default, the viewer scopes to `nomad_simulations.schema_packages`. You can extend the scope
+by setting `SCHEMA_UML_BASE_PACKAGE` to additional namespaces (comma separated) and providing a
+repo path for each.
 Make it persistent by adding the export to `~/.bashrc` or `~/.zshrc`.
 
 ### 4) Run everything with one command
@@ -106,7 +102,7 @@ curl 'http://127.0.0.1:5179/git/branches'
 
 ## 🧠 How to Use
 
-1. **Package**: Enter a Python package (e.g. `nomad_simulations.schema_packages.model_method`).
+1. **Package**: Choose a package from the dropdown (populated per branch/base namespace).
 2. **Root section**: Auto-populated from the package; pick one (e.g. `ModelMethod`) or leave empty to load all.
 3. **Build graph**: Render UML cards and composition edges.
 4. **Doc panel**: Click a class → see its docstring + list of quantities; click a quantity to view its docstring.

--- a/REPO_GUIDE.md
+++ b/REPO_GUIDE.md
@@ -38,10 +38,8 @@ export GIT_REPO_DIR=/path/to/nomad-simulations
 export SCHEMA_UML_BASE_PACKAGE=my_schema_root
 export SCHEMA_UML_PACKAGE=my_schema_root.module
 ~~~
-Default namespace scope targets `nomad_simulations.schema_packages`. To include
-`nomad_measurements`, set `SCHEMA_UML_BASE_PACKAGE` to both namespaces (comma
-separated) and ensure `NOMAD_MEASURE_REPO` points at a local clone of that
-repository.
+Default namespace scope targets `nomad_simulations.schema_packages`. To include additional
+namespaces, add them to `SCHEMA_UML_BASE_PACKAGE` (comma separated) and point each to a local clone.
 
 **Unified dev command:** `./dev.sh` starts the FastAPI backend (**5179**) and Vite frontend (**5173**), checks for `uvicorn`/`npm`, validates **SCHEMA_UML_REPO / NOMAD_SIM_REPO / GIT_REPO_DIR** points to a local git repo (a subdirectory of a clone is fine), installs frontend deps on first run, and stops both on **Ctrl+C**. Override ports via `API_PORT` / `WEB_PORT`.
 
@@ -51,6 +49,7 @@ repository.
 - Right **Under-the-hood Panel** shows **normalization methods and helper functions** that act on the selected section (based on `/usage`).
 - **Editable mode**: add, rename, or remove quantities on the selected class; dtype is validated against a supported allowlist.
 - **Bird’s-eye overview** renders packages/classes for a branch without building the full graph.
+- **Opt-in overlays**: inheritance edges and dtype/shape labels default off; enable via sidebar toggles.
 - **Exports**: download the current graph JSON or a PDF snapshot.
 - Branch diff highlights: 🟩 Added, 🟨 Changed, 🟥 Removed (edges dashed red; quantity deltas are included).
 

--- a/api/main.py
+++ b/api/main.py
@@ -128,6 +128,7 @@ def schema(
     root: str | None = Query(None),
     include_quantities: bool = Query(True),
     include_subsections: bool = Query(True),
+    include_inheritance: bool = Query(True),
     allow_cross_module: bool = Query(True),
     base_namespace: str | None = Query(None),
     user_ws=Depends(get_user_and_workspace),
@@ -142,6 +143,7 @@ def schema(
         root=root,
         include_quantities=include_quantities,
         include_subsections=include_subsections,
+        include_inheritance=include_inheritance,
         allow_cross_module=allow_cross_module,
         base_namespace=ns
     )
@@ -340,6 +342,7 @@ def add_custom_quantity(
     req: CustomQuantityRequest,
     root: str | None = Query(None),
     include_subsections: bool = Query(True),
+    include_inheritance: bool = Query(True),
     allow_cross_module: bool = Query(True),
     base_namespace: str | None = Query(None),
     user_ws=Depends(get_user_and_workspace),
@@ -359,6 +362,7 @@ def add_custom_quantity(
             root=root,
             include_quantities=True,
             include_subsections=include_subsections,
+            include_inheritance=include_inheritance,
             allow_cross_module=allow_cross_module,
             base_namespace=ns
         )

--- a/api/routes_git.py
+++ b/api/routes_git.py
@@ -196,6 +196,7 @@ def api_graph(
     root: str | None = Query(None),
     include_quantities: bool = Query(True),
     include_subsections: bool = Query(True),
+    include_inheritance: bool = Query(True),
     allow_cross_module: bool = Query(True),
     user_ws=Depends(get_user_and_workspace),
 ):
@@ -215,6 +216,7 @@ def api_graph(
             root=root,
             include_quantities=include_quantities,
             include_subsections=include_subsections,
+            include_inheritance=include_inheritance,
             allow_cross_module=allow_cross_module,
         )
         return {"branch": branch, "sha": sha, "graph": graph, "workspace": workspace_payload(workspace)}
@@ -228,6 +230,7 @@ def api_diff(
     root: str | None = Query(None),
     include_quantities: bool = Query(True),
     include_subsections: bool = Query(True),
+    include_inheritance: bool = Query(True),
     allow_cross_module: bool = Query(True),
     base_namespace: str | None = Query(None),
     user_ws=Depends(get_user_and_workspace),
@@ -245,6 +248,7 @@ def api_diff(
             "root": root,
             "include_quantities": include_quantities,
             "include_subsections": include_subsections,
+            "include_inheritance": include_inheritance,
             "allow_cross_module": allow_cross_module,
             "base_namespace": namespace,
         }

--- a/extractor/graph_builder.py
+++ b/extractor/graph_builder.py
@@ -22,7 +22,7 @@ class Node:
 class Edge:
     source: str
     target: str
-    type: str                  # "hasQuantity" | "hasSubSection"
+    type: str                  # "hasQuantity" | "hasSubSection" | "inherits"
     card: Optional[str] = None
 
 
@@ -69,6 +69,7 @@ def build_graph(
     root: str | None = None,
     include_quantities: bool = True,
     include_subsections: bool = True,
+    include_inheritance: bool = True,
     allow_cross_module: bool = True,
     base_namespace: Optional[str] = None,
     exclude_prefixes: Tuple[str, ...] = ("nomad.metainfo.",),
@@ -89,7 +90,15 @@ def build_graph(
 
     nodes: Dict[str, Node] = {}
     edges: List[Edge] = []
+    edge_keys: Set[Tuple[str, str, str]] = set()
     seen: Set[str] = set()
+
+    def add_edge(edge: Edge):
+        key = (edge.source, edge.target, edge.type)
+        if key in edge_keys:
+            return
+        edges.append(edge)
+        edge_keys.add(key)
 
     def add_section(sec_obj: Any, depth: int = 0):
         if depth > max_depth:
@@ -138,9 +147,24 @@ def build_graph(
                         owner=sec_id,
                         module=sec_mod
                     )
-                edges.append(Edge(source=sec_id, target=qid, type="hasQuantity", card=_cardinality_from(q)))
+                add_edge(Edge(source=sec_id, target=qid, type="hasQuantity", card=_cardinality_from(q)))
                 if len(nodes) > max_nodes:
                     return
+
+        if include_inheritance:
+            for base in getattr(sec_obj, "__mro__", [])[1:]:
+                if base is object:
+                    continue
+                if not _is_section(base):
+                    continue
+                base_mod = getattr(base, "__module__", "")
+                if not _module_allowed(base_mod, base_namespace, exclude_prefixes, allow_cross_module):
+                    continue
+
+                base_name = getattr(base, "__name__", str(base))
+                base_id = f"{base_mod}.{base_name}"
+                add_section(base, depth + 1)
+                add_edge(Edge(source=sec_id, target=base_id, type="inherits"))
 
         if include_subsections:
             for sname, s in _get_subsections(sec_obj):
@@ -156,7 +180,7 @@ def build_graph(
                 # add child section and quantities recursively
                 add_section(tgt_cls, depth + 1)
                 # add UML composition edge
-                edges.append(Edge(source=sec_id, target=tgt_id, type="hasSubSection", card=_cardinality_from(s)))
+                add_edge(Edge(source=sec_id, target=tgt_id, type="hasSubSection", card=_cardinality_from(s)))
                 if len(nodes) > max_nodes:
                     return
 

--- a/web/index.html
+++ b/web/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>NOMAD Schema UML (Minimal)</title>
+    <title>NOMAD Schema UML</title>
   </head>
   <body>
     <div id="root"></div>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -44,13 +44,6 @@ const WORKSPACE_PRESETS = [
     pkg: "nomad_simulations.schema_packages.model_method",
     root: "ModelMethod",
   },
-  {
-    label: "nomad-measurements",
-    namespace: "nomad_measurements",
-    branch: "main",
-    pkg: "nomad_measurements.general",
-    root: "InSituMeasurement",
-  },
 ];
 
 type WorkspaceState = {
@@ -77,7 +70,8 @@ export default function App() {
 
   const [includeQuantities, setIncludeQuantities] = useState<boolean>(true);
   const [includeSubsections, setIncludeSubsections] = useState<boolean>(true);
-  const [showQuantityMetadata, setShowQuantityMetadata] = useState<boolean>(true);
+  const [includeInheritance, setIncludeInheritance] = useState<boolean>(false);
+  const [showQuantityMetadata, setShowQuantityMetadata] = useState<boolean>(false);
 
   const [crossModules, setCrossModules] = useState<boolean>(true);
   const [namespace, setNamespace] = useState<string>(DEFAULT_NAMESPACE);
@@ -426,6 +420,7 @@ export default function App() {
               root: rootToUse,
               include_quantities: includeQuantities,
               include_subsections: includeSubsections,
+              include_inheritance: includeInheritance,
               allow_cross_module: crossModules,
               base_namespace: namespaceToUse || undefined,
             },
@@ -440,6 +435,7 @@ export default function App() {
             root: rootToUse,
             include_quantities: includeQuantities,
             include_subsections: includeSubsections,
+            include_inheritance: includeInheritance,
             allow_cross_module: crossModules,
             base_namespace: namespaceToUse || undefined,
           },
@@ -453,7 +449,7 @@ export default function App() {
     } finally {
       setLoading(false);
     }
-  }, [api, crossModules, includeQuantities, includeSubsections, normalizedNamespace, pkg, root, syncWorkspaceFromResponse, token, workspace?.branch]);
+  }, [api, crossModules, includeQuantities, includeSubsections, includeInheritance, normalizedNamespace, pkg, root, syncWorkspaceFromResponse, token, workspace?.branch]);
 
   // fetch git branches
   const loadBranches = useCallback(async () => {
@@ -527,6 +523,7 @@ export default function App() {
             root,
             include_quantities: includeQuantities,
             include_subsections: includeSubsections,
+            include_inheritance: includeInheritance,
             allow_cross_module: crossModules,
             base_namespace: normalizedNamespace || undefined,
           },
@@ -596,6 +593,7 @@ export default function App() {
           params: {
             root,
             include_subsections: includeSubsections,
+            include_inheritance: includeInheritance,
             allow_cross_module: crossModules,
             base_namespace: normalizedNamespace || undefined,
           },
@@ -909,7 +907,7 @@ export default function App() {
             <span className="pulse" />
             Schema UML
           </h3>
-          <p className="subdued">Craft diagrams, compare branches, and publish docs.</p>
+          <p className="subdued">Craft diagrams, compare branches, and edit schemas.</p>
           <div className="row" style={{ marginTop: 10 }}>
             <span className="tag">{loading || diffLoading ? "Working…" : "Ready"}</span>
             {selectedClassName ? <span className="tag">Selected: {selectedClassName}</span> : null}
@@ -971,39 +969,32 @@ export default function App() {
               </div>
             )}
           </div>
-          <div className="toggle-group" style={{ marginTop: 10 }}>
-            {WORKSPACE_PRESETS.map((ws) => (
-              <button
-                key={ws.namespace}
-                className={`toggle-chip ${normalizedNamespace === ws.namespace ? "active" : ""}`}
-                onClick={() => {
-                  handleNamespaceChange(ws.namespace);
-                  if (ws.branch) {
-                    handleBranchSelect(ws.branch);
-                  }
-                  if (ws.pkg) handlePackageSelect(ws.pkg);
-                  if (ws.root) setRoot(ws.root);
-                }}
-                title={`Set base namespace to ${ws.namespace}`}
-              >
-                {ws.label}
-              </button>
-            ))}
+          <div className="workspace-presets">
+            {WORKSPACE_PRESETS.map((ws) => {
+              return (
+                <div key={ws.namespace} className="preset-block">
+                  <button
+                    className={`workspace-preset-btn ${normalizedNamespace === ws.namespace ? "active" : ""}`}
+                    onClick={() => {
+                      handleNamespaceChange(ws.namespace);
+                      if (ws.branch) {
+                        handleBranchSelect(ws.branch);
+                      }
+                      if (ws.pkg) handlePackageSelect(ws.pkg);
+                      if (ws.root) setRoot(ws.root);
+                    }}
+                    title={`Set base namespace to ${ws.namespace}`}
+                  >
+                    {ws.label}
+                  </button>
+                </div>
+              );
+            })}
           </div>
         </CollapsibleSection>
 
         <CollapsibleSection title="Package & filters" hint="Pick a backend package and fine-tune the graph">
           <div className="action-stack">
-            <div>
-              <label className="label">Package</label>
-              <input
-                className="input"
-                value={pkg}
-                onChange={(e) => handlePackageSelect(e.target.value)}
-                placeholder={DEFAULT_PACKAGE}
-              />
-            </div>
-
             <div className="row" style={{ gap: 10, alignItems: "flex-end" }}>
               <div style={{ flex: 1 }}>
                 <label className="label">Choose from branch</label>
@@ -1078,6 +1069,14 @@ export default function App() {
                   onChange={(e) => setIncludeSubsections(e.target.checked)}
                 />
                 Subsections
+              </label>
+              <label style={{ display: "flex", gap: 6, alignItems: "center" }}>
+                <input
+                  type="checkbox"
+                  checked={includeInheritance}
+                  onChange={(e) => setIncludeInheritance(e.target.checked)}
+                />
+                Inheritance
               </label>
               <label style={{ display: "flex", gap: 6, alignItems: "center" }}>
                 <input
@@ -1200,43 +1199,24 @@ export default function App() {
             </div>
           ) : diffData ? (
             <>
-              <div className="workspace-toolbar">
-                <div>
-                  Base: {diffData.base.branch} ({diffData.base.sha.slice(0, 7)}) → Head: {diffData.head.branch}
-                  ({diffData.head.sha.slice(0, 7)})
-                </div>
-                <div className="row" style={{ gap: 10, alignItems: "center" }}>
-                  <button className="btn secondary" type="button" onClick={focusRootSection}>
-                    Go to root
-                  </button>
-                  <span className="pill diff added">🟩 Added</span>
-                  <span className="pill diff changed">🟨 Changed</span>
-                  <span className="pill diff removed">🟥 Removed</span>
-                </div>
-              </div>
               <GraphView
                 nodes={diffData.head.graph.nodes}
                 edges={diffData.head.graph.edges}
                 diff={diffData.diff}
                 showQuantityMetadata={showQuantityMetadata}
+                showInheritance={includeInheritance}
+                theme={theme}
                 onReady={setGraphHandle}
               />
             </>
           ) : graph ? (
             <>
-              <div className="workspace-toolbar" style={{ justifyContent: "space-between" }}>
-                <div>
-                  Root: <strong>{currentGraph?.root || root}</strong>
-                  {" "}from <strong>{currentGraph?.package || pkg}</strong>
-                </div>
-                <button className="btn secondary" type="button" onClick={focusRootSection}>
-                  Go to root
-                </button>
-              </div>
               <GraphView
                 nodes={graph.nodes}
                 edges={graph.edges}
                 showQuantityMetadata={showQuantityMetadata}
+                showInheritance={includeInheritance}
+                theme={theme}
                 onReady={setGraphHandle}
               />
             </>

--- a/web/src/GraphView.tsx
+++ b/web/src/GraphView.tsx
@@ -29,7 +29,7 @@ type RawNode = {
 type RawEdge = {
   source: string;
   target: string;
-  type: "hasQuantity" | "hasSubSection";
+  type: "hasQuantity" | "hasSubSection" | "inherits";
   card?: string | null;
 };
 
@@ -51,6 +51,8 @@ type Props = {
   } | null;
   onReady?: (handle: GraphExportHandle | null) => void;
   showQuantityMetadata?: boolean;
+  showInheritance?: boolean;
+  theme?: "dark" | "light";
 };
 
 const cleanType = (t?: string | null) => {
@@ -95,11 +97,28 @@ function umlLabel(
   return lines.join("\n");
 }
 
-export default function GraphView({ nodes, edges, diff, onReady, showQuantityMetadata = true }: Props) {
+export default function GraphView({
+  nodes,
+  edges,
+  diff,
+  onReady,
+  showQuantityMetadata = true,
+  showInheritance = true,
+  theme = "dark"
+}: Props) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const cyRef = useRef<Core | null>(null);
 
   const setSelected = useMemo(() => useSelection.getState().setSelected, []);
+
+  const palette = useMemo(() => {
+    const isDark = theme === "dark";
+    return {
+      composition: isDark ? "#cbd5f5" : "#475569",
+      compositionLabelBg: isDark ? "rgba(15, 23, 42, 0.72)" : "#f5f7fa",
+      inheritance: isDark ? "#e2e8f0" : "#0f172a",
+    };
+  }, [theme]);
 
   const quantityDiffs = useMemo(() => {
     const map = new Map<
@@ -150,7 +169,7 @@ export default function GraphView({ nodes, edges, diff, onReady, showQuantityMet
   // - attrsMap: section id -> display lines for UML
   // - methodsMap: section id -> methods
   // - quantitiesByOwner: section id -> QtyMeta[]  (for DocPanel)
-  const { sectionsMap, attrsMap, methodsMap, compEdges, quantitiesByOwner } = useMemo(() => {
+  const { sectionsMap, attrsMap, methodsMap, umlEdges, quantitiesByOwner } = useMemo(() => {
     const sections = new Map<string, RawNode>();
     const attrs = new Map<
       string,
@@ -246,18 +265,24 @@ export default function GraphView({ nodes, edges, diff, onReady, showQuantityMet
     if (diff?.edges?.removed?.length) {
       diff.edges.removed.forEach((e: any) => {
         if (!e?.source || !e?.target) return;
+        const type = (e.type as RawEdge["type"]) ?? "hasSubSection";
         baseEdges.push({
           source: e.source,
           target: e.target,
-          type: (e.type as any) ?? "hasSubSection",
+          type,
           card: e.card ?? undefined
         });
       });
     }
 
-    const subs = baseEdges.filter(e => e.type === "hasSubSection");
-    return { sectionsMap: sections, attrsMap: attrs, methodsMap: methods, compEdges: subs, quantitiesByOwner: qByOwner };
-  }, [graphNodes, edges, quantityDiffs, diff]);
+    const umlEdges = baseEdges.filter((e) => {
+      if (e.type === "hasSubSection") return true;
+      if (e.type === "inherits") return showInheritance;
+      return false;
+    });
+
+    return { sectionsMap: sections, attrsMap: attrs, methodsMap: methods, umlEdges, quantitiesByOwner: qByOwner };
+  }, [graphNodes, edges, quantityDiffs, diff, showInheritance]);
 
   useEffect(() => {
     if (!containerRef.current) return;
@@ -284,14 +309,16 @@ export default function GraphView({ nodes, edges, diff, onReady, showQuantityMet
       });
     }
 
-    compEdges.forEach((e, i) => {
+    umlEdges.forEach((e, i) => {
       if (!sectionsMap.has(e.source) || !sectionsMap.has(e.target)) return;
+      const relationship = e.type === "inherits" ? "inheritance" : "composition";
       elements.push({
         data: {
-          id: `assoc:${i}:${e.source}->${e.target}`,
+          id: `assoc:${relationship}:${i}:${e.source}->${e.target}`,
           source: e.source,
           target: e.target,
-          type: "composition",
+          type: e.type,
+          relationship,
           card: e.card ?? ""
         }
       });
@@ -329,23 +356,38 @@ export default function GraphView({ nodes, edges, diff, onReady, showQuantityMet
           } as any
         },
         {
-          selector: "edge[type='composition']",
+          selector: "edge[relationship='composition']",
           style: {
-            "line-color": "#475569",
+            "line-color": palette.composition,
             width: 2,
             "curve-style": "segments",
             "source-arrow-shape": "diamond",
-            "source-arrow-color": "#475569",
+            "source-arrow-color": palette.composition,
             "target-arrow-shape": "triangle",
-            "target-arrow-color": "#475569",
+            "target-arrow-color": palette.composition,
             "arrow-scale": 1.1,
             label: "data(card)",
             "font-size": 10,
             "text-rotation": "autorotate",
             "text-margin-y": -6,
-            "text-background-color": "#f5f7fa",
+            "text-background-color": palette.compositionLabelBg,
             "text-background-opacity": 1,
-            "text-background-padding": "2px"
+            "text-background-padding": "2px",
+            color: palette.composition
+          }
+        },
+        {
+          selector: "edge[relationship='inheritance']",
+          style: {
+            "line-color": palette.inheritance,
+            width: 2,
+            "curve-style": "bezier",
+            "target-arrow-shape": "triangle",
+            "target-arrow-color": palette.inheritance,
+            "arrow-scale": 1.1,
+            "target-arrow-fill": "hollow",
+            "line-style": "dashed",
+            "line-dash-pattern": [10, 8]
           }
         },
         { selector: ".hidden", style: { display: "none" } },
@@ -508,7 +550,7 @@ export default function GraphView({ nodes, edges, diff, onReady, showQuantityMet
       onReady?.(null);
       cyRef.current?.destroy();
     };
-  }, [sectionsMap, attrsMap, methodsMap, compEdges, quantitiesByOwner, diff, setSelected, onReady, showQuantityMetadata]);
+  }, [sectionsMap, attrsMap, methodsMap, umlEdges, quantitiesByOwner, diff, setSelected, onReady, showQuantityMetadata, palette]);
 
   return <div className="graph" ref={containerRef} />;
 }

--- a/web/src/components/DocPanel.tsx
+++ b/web/src/components/DocPanel.tsx
@@ -51,7 +51,7 @@ function QtyRow({ q, onClick, onEdit, onRemove, editableMode, disabled }: { q: Q
           <div style={{ fontSize: 11, opacity: 0.7 }}>{meta.join("  ")}</div>
         </div>
         {diffLabel ? <span className={diffClass || "pill"}>{diffLabel}</span> : null}
-        <div className="tag" style={{ borderColor: "rgba(124, 58, 237, 0.4)", color: "#c7d2fe" }}>View</div>
+        <div className="tag view">View</div>
       </button>
 
       {editableMode && (

--- a/web/src/components/UnderTheHoodPanel.tsx
+++ b/web/src/components/UnderTheHoodPanel.tsx
@@ -53,11 +53,6 @@ const UnderTheHoodPanel: React.FC<Props> = ({ apiBase, token }) => {
 
   return (
     <div className="panel under-the-hood-panel">
-      <div className="uth-header">
-        <div className="meta-label">Under the hood</div>
-        <div className="hint">Raw schema structure</div>
-      </div>
-
       {!selected || selected.kind !== 'class' ? (
         <div className="uth-empty">Select a section to see normalization and utility functions.</div>
       ) : (

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -7,6 +7,12 @@
   --font-mono: "JetBrains Mono", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", monospace;
   --accent: #7c3aed;
   --accent-2: #22d3ee;
+  --eyebrow-color: #dce7ff;
+  --view-tag-bg: rgba(124, 58, 237, 0.14);
+  --view-tag-border: rgba(124, 58, 237, 0.5);
+  --view-tag-fg: #c7d2fe;
+  --pill-warning-bg: rgba(234, 179, 8, 0.22);
+  --pill-warning-fg: #fef9c3;
 }
 
 [data-theme="dark"] {
@@ -43,6 +49,7 @@
   --code-chip-color: #cbd5f5;
   --subtitle: #cbd5f5;
   --ghost: rgba(255, 255, 255, 0.04);
+  --eyebrow-color: #dce7ff;
   color-scheme: dark;
 }
 
@@ -80,6 +87,12 @@
   --code-chip-color: #0f172a;
   --subtitle: #475569;
   --ghost: rgba(15, 23, 42, 0.04);
+  --eyebrow-color: #334155;
+  --view-tag-bg: rgba(124, 58, 237, 0.12);
+  --view-tag-border: rgba(124, 58, 237, 0.38);
+  --view-tag-fg: #312e81;
+  --pill-warning-bg: rgba(234, 179, 8, 0.18);
+  --pill-warning-fg: #92400e;
   color-scheme: light;
 }
 
@@ -125,7 +138,7 @@ main {
 .eyebrow {
   text-transform: uppercase;
   letter-spacing: 0.12em;
-  color: #c4d3ff;
+  color: var(--eyebrow-color);
   font-size: 11px;
   margin: 0 0 4px 0;
 }
@@ -273,6 +286,13 @@ hr { border:0; border-top:1px solid var(--panel-border); margin:12px 0; }
   border: 1px solid var(--panel-border);
   font-size: 12px;
 }
+.tag.view {
+  background: var(--view-tag-bg);
+  border-color: var(--view-tag-border);
+  color: var(--view-tag-fg);
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
 
 .control-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 10px; }
 
@@ -356,8 +376,69 @@ hr { border:0; border-top:1px solid var(--panel-border); margin:12px 0; }
 .pill.diff.added { background: var(--diff-added-bg); color: var(--diff-added-fg); }
 .pill.diff.changed { background: var(--diff-changed-bg); color: var(--diff-changed-fg); }
 .pill.diff.removed { background: var(--diff-removed-bg); color: var(--diff-removed-fg); }
-.pill.warning { background: rgba(234, 179, 8, 0.16); color: #fef9c3; }
+.pill.warning { background: var(--pill-warning-bg); color: var(--pill-warning-fg); }
 .pill.muted { background: rgba(148, 163, 184, 0.18); color: var(--muted); }
+
+.workspace-presets {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.preset-block {
+  padding: 12px;
+  border: 1px solid var(--panel-border);
+  border-radius: 14px;
+  background: var(--card);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
+}
+
+.preset-block.warning {
+  border-color: var(--pill-warning-fg);
+  background: color-mix(in srgb, var(--pill-warning-bg) 55%, transparent);
+}
+
+.preset-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.preset-title {
+  font-weight: 700;
+  color: var(--text-primary);
+  text-transform: capitalize;
+}
+
+.workspace-preset-btn {
+  width: 100%;
+  justify-content: center;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid var(--panel-border);
+  background: linear-gradient(135deg, var(--surface), var(--card));
+  color: var(--text-primary);
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease, border-color 120ms ease;
+}
+
+.workspace-preset-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.12);
+}
+
+.workspace-preset-btn.active {
+  border-color: rgba(124, 58, 237, 0.45);
+  box-shadow: 0 10px 28px rgba(124, 58, 237, 0.22);
+  background: linear-gradient(135deg, rgba(124, 58, 237, 0.15), rgba(34, 211, 238, 0.14));
+}
 
 .overview-search {
   padding: 8px 10px;

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -11,6 +11,7 @@ export type GraphEdgeData = {
   id?: string;
   source: string;
   target: string;
+  type?: 'hasQuantity' | 'hasSubSection' | 'inherits';
 };
 
 export type GraphPayload = {


### PR DESCRIPTION
1) Polished workspace presets: removed the nomad-measurements preset/under-construction badge, kept only nomad-simulations, restyled preset cards/buttons, and removed the redundant package text field.

2) Improved diagram defaults and visibility: inheritance and dtype/shapes toggles default to off; inheritance edges and “View” badges are theme-aware; under-the-hood panel no longer repeats its title.

3) Updated branding copy: page title and sidebar tagline refreshed; markdown docs aligned with the new defaults and preset scope.