### PR TITLE
Document authentication requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,27 @@ What it does:
 - Stops both together on **Ctrl+C** (no manual job control needed).
 - Exits early with a helpful message if `uvicorn` or `npm` are missing (activate your virtualenv first).
 
+### 5) Authenticate (required)
+
+The backend now requires a bearer token for every endpoint except `/auth/login`. A default user is created at startup:
+
+- **Username**: `admin` (override via `SCHEMA_UML_DEFAULT_USER`)
+- **Password**: `admin` (override via `SCHEMA_UML_DEFAULT_PASSWORD`)
+
+Use the sign-in form in the UI or fetch a token manually:
+
+```bash
+TOKEN=$(curl -s -X POST http://127.0.0.1:5179/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"admin","password":"admin"}' | jq -r .access_token)
+```
+
+Include the token when calling other endpoints:
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" 'http://127.0.0.1:5179/roots?package=nomad_simulations.schema_packages.model_method'
+```
+
 Stop both with **Ctrl+C**. Override ports via `API_PORT` / `WEB_PORT` env vars.
 
 Branch-specific render (no diff): set **Package branch** to load `/graph` for a chosen branch instead of the working tree.

--- a/REPO_GUIDE.md
+++ b/REPO_GUIDE.md
@@ -29,6 +29,11 @@ A structured overview of the repository for developers to navigate, understand, 
 - `GET /git/packages` — list Python modules under a base package
 - `GET /usage` — list normalize methods / helper functions for a given section class
 
+**Authentication:**
+- Every endpoint (except `/auth/login`) requires a bearer token. The backend seeds a default user on startup:
+  - `SCHEMA_UML_DEFAULT_USER` (default `admin`)
+  - `SCHEMA_UML_DEFAULT_PASSWORD` (default `admin`)
+
 **Environment variables (one of):**
 ~~~bash
 export SCHEMA_UML_REPO=/path/to/your-schema


### PR DESCRIPTION
## Summary
- add authentication instructions and token example to README quick start
- document default user credentials and bearer token requirement in repo guide

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b1948a9e083209723baaa2f66b264)