### PR TITLE
persisted edits and keep audit trail clean

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -189,6 +189,9 @@ async def schema(
         db=db, user_id=user["id"], workspace=workspace, package=pkg, base_namespace=ns
     )
     data, apply_conflicts = _apply_persisted_edits(data, persisted)
+    # Surface the list of applied persisted edits so the frontend can show them in the audit trail.
+    if persisted:
+        data["applied_edits"] = [_serialize_edit(edit) for edit in persisted]
     data["workspace"] = workspace_payload(workspace)
     conflicts = stale_conflicts + apply_conflicts
     if conflicts:

--- a/api/main.py
+++ b/api/main.py
@@ -189,9 +189,9 @@ async def schema(
         db=db, user_id=user["id"], workspace=workspace, package=pkg, base_namespace=ns
     )
     data, apply_conflicts = _apply_persisted_edits(data, persisted)
-    # Surface the list of applied persisted edits so the frontend can show them in the audit trail.
-    if persisted:
-        data["applied_edits"] = [_serialize_edit(edit) for edit in persisted]
+    applied = _applied_edits(persisted, apply_conflicts)
+    if applied:
+        data["applied_edits"] = [_serialize_edit(edit) for edit in applied]
     data["workspace"] = workspace_payload(workspace)
     conflicts = stale_conflicts + apply_conflicts
     if conflicts:
@@ -394,6 +394,35 @@ def _apply_persisted_edits(graph: dict, edits: list[PersistedEdit]) -> tuple[dic
         except HTTPException as exc:
             conflicts.append({"edit": _serialize_edit(edit), "reason": "validation_error", "detail": exc.detail})
     return graph, conflicts
+
+
+def _applied_edits(persisted: list[PersistedEdit], apply_conflicts: list[dict]) -> list[PersistedEdit]:
+    """
+    Return only the persisted edits that were successfully applied (i.e., not present in apply_conflicts).
+    Conflicts carry a serialized edit; we compare by edit_id when available, otherwise by a tuple signature.
+    """
+    conflict_keys: set[tuple[str, str, str | None]] = set()
+    for conflict in apply_conflicts or []:
+        edit_obj = conflict.get("edit") if isinstance(conflict, dict) else None
+        if not isinstance(edit_obj, dict):
+            continue
+        edit_id = edit_obj.get("id")
+        if edit_id:
+            conflict_keys.add(("id", edit_id, None))
+            continue
+        signature = (
+            edit_obj.get("edit_type") or "",
+            edit_obj.get("class_name") or "",
+            edit_obj.get("quantity_name") or None,
+        )
+        conflict_keys.add(signature)
+
+    def _key(e: PersistedEdit) -> tuple[str, str, str | None]:
+        if e.edit_id:
+            return ("id", e.edit_id, None)
+        return (e.edit_type, e.class_name, e.quantity_name or None)
+
+    return [e for e in persisted if _key(e) not in conflict_keys]
 
 
 async def _persisted_state(

--- a/api/tests/test_edit_persistence.py
+++ b/api/tests/test_edit_persistence.py
@@ -137,3 +137,85 @@ def test_branch_conflict_marks_edits_and_blocks_overwrite(client, tmp_path: Path
     detail = conflicting.json()["detail"]
     assert detail["stored_base_sha"] == "old-sha"
     assert detail["current_base_sha"] == "new-sha"
+
+
+def test_schema_includes_applied_edits_when_present(client, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """
+    GET /schema should expose applied_edits when persisted custom edits exist so the
+    frontend can surface them in the audit trail.
+    """
+    pkg_name = _create_dummy_package(tmp_path)
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    # Persist a custom quantity (stores edit and replays it)
+    create_resp = client.post(
+        "/schema/custom-quantity",
+        json={
+            "package": pkg_name,
+            "class_name": "TargetSection",
+            "quantity_name": "user_defined",
+            "dtype": "float",
+            "docstring": "Persist me",
+        },
+    )
+    assert create_resp.status_code == 200
+
+    # Subsequent schema call should include applied_edits
+    schema_resp = client.get("/schema", params={"package": pkg_name})
+    assert schema_resp.status_code == 200
+    payload = schema_resp.json()
+    applied = payload.get("applied_edits")
+    assert isinstance(applied, list)
+    assert any(
+        e.get("edit_type") == "quantity"
+        and e.get("quantity_name") == "user_defined"
+        and e.get("class_name") == "TargetSection"
+        for e in applied
+    )
+
+
+def test_schema_omits_applied_edits_when_none_exist(client, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """
+    When no persisted edits exist, applied_edits should be absent or empty.
+    """
+    pkg_name = _create_dummy_package(tmp_path)
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    schema_resp = client.get("/schema", params={"package": pkg_name})
+    assert schema_resp.status_code == 200
+    payload = schema_resp.json()
+    applied = payload.get("applied_edits")
+    assert applied in (None, [])
+
+
+def test_applied_edits_excluded_when_edit_is_stale(client, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """
+    Persisted edits based on a stale branch head should show in edit_conflicts,
+    not in applied_edits.
+    """
+    pkg_name = _create_dummy_package(tmp_path)
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    # Persist with old branch head
+    monkeypatch.setattr(main, "_current_branch_head", lambda branch, base: "old-sha")
+    create_resp = client.post(
+        "/schema/custom-quantity",
+        json={
+            "package": pkg_name,
+            "class_name": "TargetSection",
+            "quantity_name": "user_defined",
+            "dtype": "float",
+            "docstring": "Persist me",
+        },
+    )
+    assert create_resp.status_code == 200
+
+    # Now branch head changes; the persisted edit should be reported as conflict, not applied.
+    monkeypatch.setattr(main, "_current_branch_head", lambda branch, base: "new-sha")
+    schema_resp = client.get("/schema", params={"package": pkg_name})
+    assert schema_resp.status_code == 200
+    payload = schema_resp.json()
+    assert payload.get("edit_conflicts")
+    assert payload["edit_conflicts"][0]["reason"] == "stale_branch_head"
+    applied = payload.get("applied_edits")
+    assert applied in (None, [])  # explicitly ensure not applied

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -440,6 +440,12 @@ export default function App() {
     setAuditTrail((prev) => prev.map((entry) => ({ ...entry, replayable: false })));
   }, []);
 
+  const archiveAllAuditEntries = useCallback(() => {
+    setAuditTrail((prev) =>
+      prev.length ? prev.map((entry) => ({ ...entry, replayable: false })) : prev
+    );
+  }, [setAuditTrail]);
+
   const appendAudit = useCallback(
     (change: AuditTrailEntry["change"], description: string) => {
       const now = new Date().toISOString();
@@ -1222,12 +1228,6 @@ export default function App() {
     },
     [setAuditTrail]
   );
-
-  const archiveAllAuditEntries = useCallback(() => {
-    setAuditTrail((prev) =>
-      prev.length ? prev.map((entry) => ({ ...entry, replayable: false })) : prev
-    );
-  }, [setAuditTrail]);
 
   useEffect(() => {
     archiveStaleAuditEntries(graph);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10,7 +10,15 @@ import CollapsibleSection from "./components/CollapsibleSection";
 import { useSelection } from "./store/selection";
 import { jsPDF } from "jspdf";
 import type { AuditTrailEntry, QuantityNode, UmlClassNode, UmlGraphState } from "./types/uml";
-import { ensureDiffResponse, ensureGraphResponse, type ApiEdge, type ApiGraph, type ApiNode, type DiffResponse } from "./types/api";
+import {
+  ensureDiffResponse,
+  ensureGraphResponse,
+  type ApiEdge,
+  type ApiGraph,
+  type ApiNode,
+  type AppliedEdit,
+  type DiffResponse
+} from "./types/api";
 import type { WorkspaceState } from "./types/workspace";
 import { API_FEATURE_HEADER, API_VERSION, API_VERSION_HEADER, DEFAULT_FEATURE_FLAGS } from "./constants/api";
 import { DEFAULT_API, DEFAULT_BRANCH, DEFAULT_NAMESPACE, DEFAULT_ROOT } from "./constants/defaults";
@@ -783,6 +791,11 @@ export default function App() {
       }
       setGraph(parsed);
       setBaseGraph(parsed);
+      // If the server returned a clean graph without applied persisted edits, archive any local audit history
+      // so “active edits” reflects only new work in this session.
+      if (!parsed.applied_edits || parsed.applied_edits.length === 0) {
+        archiveAllAuditEntries();
+      }
     } catch (e: unknown) {
       const message = formatApiError(e);
       setErr(message || "Failed to load graph");
@@ -996,6 +1009,119 @@ export default function App() {
     };
   }, [toQuantityNode]);
 
+  const changeFromAppliedEdit = useCallback(
+    (edit: AppliedEdit, graph: ApiGraph): AuditTrailEntry["change"] | null => {
+      const normalizedPackage = normalizeModule(edit.package || graph.package) || graph.package;
+
+      if (edit.edit_type === "class") {
+        const sectionNode =
+          graph.nodes.find(
+            (n) =>
+              n.kind === "section" &&
+              (normalizeId(n.id) === normalizeId(`${normalizedPackage}.${edit.class_name}`) ||
+                normalizeLabel(n.label, n.id) === edit.class_name)
+          ) || null;
+
+        const classId = normalizeId(sectionNode?.id || `${normalizedPackage}.${edit.class_name}`);
+        const ownedQuantities = graph.nodes
+          .filter((n) => n.kind === "quantity" && normalizeId(n.owner) === classId)
+          .map(toQuantityNode);
+        const parentEdge = graph.edges.find(
+          (e) =>
+            (e.type === "inherits" || e.type === "hasSubSection") &&
+            normalizeId(e.target) === classId
+        );
+        const parentRelation: "inherits" | "hasSubSection" | null =
+          parentEdge?.type === "inherits"
+            ? "inherits"
+            : parentEdge?.type === "hasSubSection"
+              ? "hasSubSection"
+              : null;
+
+        const cls: UmlClassNode = {
+          id: classId,
+          name: normalizeLabel(sectionNode?.label ?? edit.class_name ?? classId, classId),
+          doc: sectionNode?.doc ?? edit.docstring ?? null,
+          module: sectionNode?.module ?? normalizedPackage,
+          path: sectionNode?.path ?? null,
+          line: typeof sectionNode?.line === "number" ? sectionNode.line : null,
+          quantities: ownedQuantities,
+          parentId: parentEdge ? normalizeId(parentEdge.source) : null,
+          parentRelation,
+        };
+        return { type: "add-class", cls };
+      }
+
+      // quantity edit
+      const classId = normalizeId(`${normalizedPackage}.${edit.class_name}`);
+      const quantityNode =
+        graph.nodes.find(
+          (n) =>
+            n.kind === "quantity" &&
+            normalizeId(n.owner) === classId &&
+            (normalizeId(n.id) === normalizeId(`${classId}.${edit.quantity_name || ""}`) ||
+              normalizeLabel(n.label, n.id) === edit.quantity_name)
+        ) || null;
+
+      const quantity: QuantityNode = quantityNode
+        ? toQuantityNode(quantityNode)
+        : {
+            id: normalizeId(`${classId}.${edit.quantity_name || "quantity"}`),
+            name: edit.quantity_name || "quantity",
+            dtype: edit.dtype ?? undefined,
+            doc: edit.docstring ?? null,
+            shape: null,
+            card: null,
+            path: null,
+            line: null,
+            ownerId: classId,
+          };
+
+      return { type: "add-quantity", classId, quantity };
+    },
+    [normalizeModule, normalizeId, normalizeLabel, toQuantityNode]
+  );
+
+  const seedAuditFromAppliedEdits = useCallback(
+    (graphWithEdits: ApiGraph | null) => {
+      const applied = graphWithEdits?.applied_edits;
+      if (!graphWithEdits || !applied || !applied.length) return;
+
+      const pkgForEntries = normalizePackageName(graphWithEdits.package);
+      setAuditTrail((prev) => {
+        const existingIds = new Set(prev.map((e) => e.id));
+        const next: AuditTrailEntry[] = [];
+
+        applied.forEach((edit) => {
+          const editId = edit.id || `${edit.edit_type}-${edit.class_name}-${edit.quantity_name || ""}`;
+          const auditId = `persisted-${pkgForEntries}-${editId}`;
+          if (existingIds.has(auditId)) return;
+
+          const change = changeFromAppliedEdit(edit, graphWithEdits);
+          if (!change) return;
+
+          const description =
+            edit.edit_type === "quantity"
+              ? `Persisted quantity ${edit.quantity_name || ""} on ${edit.class_name}`
+              : `Persisted class ${edit.class_name}`;
+
+          next.push({
+            id: auditId,
+            timestamp: edit.updated_at || edit.created_at || new Date().toISOString(),
+            description,
+            change,
+            package: edit.package || graphWithEdits.package,
+            replayable: false,
+          });
+        });
+
+        if (!next.length) return prev;
+        return [...prev, ...next];
+      });
+    },
+    [changeFromAppliedEdit, normalizePackageName, setAuditTrail]
+  );
+
   const toggleEmptyMode = useCallback(async () => {
     const nextShouldBeEmpty = !emptyCanvasActive;
     setStartEmpty(nextShouldBeEmpty);
@@ -1038,10 +1164,65 @@ export default function App() {
   }, [buildUmlState, graph]);
 
   useEffect(() => {
+    seedAuditFromAppliedEdits(graph);
+  }, [graph, seedAuditFromAppliedEdits]);
+
+  useEffect(() => {
     if (!auditTrail.length && graph) {
       setBaseGraph(graph);
     }
   }, [auditTrail.length, graph]);
+
+  const archiveStaleAuditEntries = useCallback(
+    (g: ApiGraph | null) => {
+      if (!g) return;
+      const classIds = new Set(
+        g.nodes.filter((n) => n.kind === "section").map((n) => normalizeId(n.id))
+      );
+      const quantityIds = new Set(
+        g.nodes.filter((n) => n.kind === "quantity").map((n) => normalizeId(n.id))
+      );
+
+      setAuditTrail((prev) => {
+        let mutated = false;
+        const next = prev.map((entry) => {
+          if (entry.replayable === false) return entry;
+          const change = entry.change;
+          const exists = (() => {
+            switch (change.type) {
+              case "add-class":
+                return classIds.has(normalizeId(change.cls.id));
+              case "remove-class":
+                return !classIds.has(normalizeId(change.cls.id));
+              case "add-quantity":
+                return quantityIds.has(normalizeId(change.quantity.id));
+              case "remove-quantity":
+                return !quantityIds.has(normalizeId(change.quantity.id));
+              case "edit-quantity":
+                return quantityIds.has(normalizeId(change.after.id));
+              default:
+                return false;
+            }
+          })();
+          if (exists) return entry;
+          mutated = true;
+          return { ...entry, replayable: false };
+        });
+        return mutated ? next : prev;
+      });
+    },
+    [setAuditTrail]
+  );
+
+  const archiveAllAuditEntries = useCallback(() => {
+    setAuditTrail((prev) =>
+      prev.length ? prev.map((entry) => ({ ...entry, replayable: false })) : prev
+    );
+  }, [setAuditTrail]);
+
+  useEffect(() => {
+    archiveStaleAuditEntries(graph);
+  }, [archiveStaleAuditEntries, graph]);
 
   useEffect(() => {
     if (!umlState) {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -804,7 +804,7 @@ export default function App() {
     } finally {
       setLoading(false);
     }
-  }, [api, crossModules, enqueueGraphTask, includeQuantities, includeSubsections, includeInheritance, normalizedNamespace, pkg, root, setStartEmpty, startEmpty, syncWorkspaceFromResponse, token, workspaceBranch]);
+  }, [api, archiveAllAuditEntries, crossModules, enqueueGraphTask, includeQuantities, includeSubsections, includeInheritance, normalizedNamespace, pkg, root, setStartEmpty, startEmpty, syncWorkspaceFromResponse, token, workspaceBranch]);
 
   const resetEmptyCanvas = useCallback(async () => {
     if (!token) {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1188,25 +1188,34 @@ export default function App() {
         const next = prev.map((entry) => {
           if (entry.replayable === false) return entry;
           const change = entry.change;
-          const exists = (() => {
+          const applied = (() => {
             switch (change.type) {
               case "add-class":
+                // Change is already reflected if class is present.
                 return classIds.has(normalizeId(change.cls.id));
               case "remove-class":
+                // Reflected if class is gone.
                 return !classIds.has(normalizeId(change.cls.id));
               case "add-quantity":
+                // Reflected if quantity is present.
                 return quantityIds.has(normalizeId(change.quantity.id));
               case "remove-quantity":
+                // Reflected if quantity is gone.
                 return !quantityIds.has(normalizeId(change.quantity.id));
               case "edit-quantity":
+                // Reflected if the updated quantity exists.
                 return quantityIds.has(normalizeId(change.after.id));
               default:
                 return false;
             }
           })();
-          if (exists) return entry;
+          // If the change is already applied in the server graph, archive it.
+          if (applied) {
+            mutated = true;
+            return { ...entry, replayable: false };
+          }
           mutated = true;
-          return { ...entry, replayable: false };
+          return entry;
         });
         return mutated ? next : prev;
       });

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -30,6 +30,7 @@ export type ApiGraph = {
   nodes: ApiNode[];
   edges: ApiEdge[];
   workspace?: WorkspaceState;
+  applied_edits?: AppliedEdit[];
 };
 
 export type BranchGraphPayload = {
@@ -52,6 +53,50 @@ const isRecord = (v: unknown): v is Record<string, unknown> =>
   typeof v === "object" && v !== null && !Array.isArray(v);
 
 const asString = (v: unknown) => (typeof v === "string" ? v : "");
+
+export type AppliedEdit = {
+  id?: string;
+  user_id?: string;
+  branch?: string;
+  package?: string;
+  class_name: string;
+  quantity_name?: string | null;
+  dtype?: string | null;
+  docstring?: string | null;
+  parent_name?: string | null;
+  parent_relation?: string | null;
+  edit_type: "class" | "quantity";
+  base_sha?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+};
+
+const ensureAppliedEdit = (value: unknown): AppliedEdit => {
+  if (!isRecord(value)) {
+    throw new Error("Applied edit is not an object");
+  }
+  const edit_type = value.edit_type;
+  if (edit_type !== "class" && edit_type !== "quantity") {
+    throw new Error(`Unexpected edit_type: ${String(edit_type)}`);
+  }
+
+  return {
+    id: asString(value.id) || undefined,
+    user_id: asString(value.user_id) || undefined,
+    branch: asString(value.branch) || undefined,
+    package: asString(value.package) || undefined,
+    class_name: asString(value.class_name),
+    quantity_name: typeof value.quantity_name === "string" ? value.quantity_name : null,
+    dtype: typeof value.dtype === "string" ? value.dtype : null,
+    docstring: typeof value.docstring === "string" ? value.docstring : null,
+    parent_name: typeof value.parent_name === "string" ? value.parent_name : null,
+    parent_relation: typeof value.parent_relation === "string" ? value.parent_relation : null,
+    edit_type,
+    base_sha: typeof value.base_sha === "string" ? value.base_sha : null,
+    created_at: typeof value.created_at === "string" ? value.created_at : null,
+    updated_at: typeof value.updated_at === "string" ? value.updated_at : null,
+  };
+};
 
 const ensureWorkspace = (value: unknown): WorkspaceState | undefined => {
   if (!isRecord(value)) return undefined;
@@ -133,6 +178,9 @@ export const ensureGraphResponse = (payload: unknown): ApiGraph => {
     nodes: nodesRaw.map(ensureNode),
     edges: edgesRaw.map(ensureEdge),
     workspace: ensureWorkspace(payload.workspace),
+    applied_edits: Array.isArray(payload.applied_edits)
+      ? payload.applied_edits.map(ensureAppliedEdit)
+      : undefined,
   };
 };
 

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -79,13 +79,21 @@ const ensureAppliedEdit = (value: unknown): AppliedEdit => {
   if (edit_type !== "class" && edit_type !== "quantity") {
     throw new Error(`Unexpected edit_type: ${String(edit_type)}`);
   }
+  const class_name = asString(value.class_name);
+  if (!class_name) {
+    throw new Error("Applied edit missing class_name");
+  }
+  const quantity_name_raw = value.quantity_name;
+  if (edit_type === "quantity" && (typeof quantity_name_raw !== "string" || !quantity_name_raw)) {
+    throw new Error("Applied quantity edit missing quantity_name");
+  }
 
   return {
     id: asString(value.id) || undefined,
     user_id: asString(value.user_id) || undefined,
     branch: asString(value.branch) || undefined,
     package: asString(value.package) || undefined,
-    class_name: asString(value.class_name),
+    class_name,
     quantity_name: typeof value.quantity_name === "string" ? value.quantity_name : null,
     dtype: typeof value.dtype === "string" ? value.dtype : null,
     docstring: typeof value.docstring === "string" ? value.docstring : null,

--- a/web/tests/audit-trail-applied-edits.test.tsx
+++ b/web/tests/audit-trail-applied-edits.test.tsx
@@ -1,0 +1,139 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import App from '../src/App';
+import { useWorkspaceStore } from '../src/store/workspace';
+
+const classId = 'pkg.custom_schema.AtomsState';
+
+const graphWithApplied = {
+  package: 'pkg.custom_schema',
+  root: '',
+  nodes: [
+    { id: classId, kind: 'section', label: 'AtomsState' },
+    { id: `${classId}.user_defined`, kind: 'quantity', label: 'user_defined', owner: classId },
+  ],
+  edges: [{ source: classId, target: `${classId}.user_defined`, type: 'hasQuantity' }],
+  applied_edits: [
+    {
+      edit_type: 'quantity',
+      class_name: 'AtomsState',
+      quantity_name: 'user_defined',
+      dtype: 'float',
+      package: 'pkg.custom_schema',
+    },
+  ],
+};
+
+const graphWithoutApplied = {
+  package: 'pkg.custom_schema',
+  root: '',
+  nodes: [{ id: classId, kind: 'section', label: 'AtomsState' }],
+  edges: [],
+};
+
+const mockGet = vi.fn();
+const mockPost = vi.fn();
+const mockPut = vi.fn();
+const mockDelete = vi.fn();
+
+vi.mock('axios', () => {
+  const create = () => ({
+    get: mockGet,
+    post: mockPost,
+    put: mockPut,
+    delete: mockDelete,
+    interceptors: { request: { use: vi.fn() } },
+  });
+  const axios = Object.assign(create, { create, post: vi.fn() });
+  return { default: axios };
+});
+
+// Minimal GraphView stub; avoids cytoscape in tests.
+vi.mock('../src/GraphView', () => ({
+  __esModule: true,
+  default: () => <div>GraphView</div>,
+}));
+
+const commonGet = (graphPayload: object) => async (url: string, options?: { params?: Record<string, unknown> }) => {
+  if (url === '/workspace') {
+    return { data: { workspace: { branch: 'develop', package: 'pkg.custom_schema', base_namespace: 'pkg' }, user: { username: 'tester' } } };
+  }
+  if (url === '/schema') {
+    if (options?.params?.empty) return { data: graphPayload };
+    return { data: graphPayload };
+  }
+  if (url === '/git/branches') return { data: { branches: ['develop'] } };
+  if (url === '/git/packages') return { data: { packages: ['pkg.custom_schema'] } };
+  if (url === '/roots') return { data: { sections: ['AtomsState'] } };
+  return { data: {} };
+};
+
+const primeWorkspace = () => {
+  useWorkspaceStore.getState().setPkg('pkg.custom_schema');
+  useWorkspaceStore.getState().setBaseNamespace('pkg');
+  useWorkspaceStore.getState().setStartEmpty(false);
+  window.localStorage.setItem('schema-uml-token', 'tok');
+  window.localStorage.setItem('schema-uml-username', 'tester');
+};
+
+describe('Audit trail seeding from applied edits', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+    mockPost.mockReset();
+    mockPut.mockReset();
+    mockDelete.mockReset();
+    window.localStorage.clear();
+    primeWorkspace();
+
+    if (!('ResizeObserver' in window)) {
+      // @ts-expect-error happy-dom lacks ResizeObserver
+      window.ResizeObserver = class {
+        observe() {}
+        disconnect() {}
+      };
+    }
+  });
+
+  it('shows applied edits as archived and reports 0 active edits', async () => {
+    mockGet.mockImplementation(commonGet(graphWithApplied));
+    mockPut.mockResolvedValue({ data: { workspace: { branch: 'develop', package: 'pkg.custom_schema', base_namespace: 'pkg' } } });
+
+    render(<App />);
+    const user = userEvent.setup();
+
+    await user.click(await screen.findByRole('button', { name: /\+ Start from empty canvas/i }));
+
+    await waitFor(() => expect(screen.queryAllByText(/0 active edits/i).length).toBeGreaterThan(0));
+    const persisted = screen.getAllByText((_, node) => node?.textContent?.includes('Persisted quantity user_defined on AtomsState') ?? false);
+    expect(persisted[0]).toHaveTextContent(/archived/i);
+  });
+
+  it('archives preexisting local audit entries when server sends no applied edits', async () => {
+    const storedAudit = [
+      {
+        id: 'local-1',
+        timestamp: new Date().toISOString(),
+        description: 'Old local change',
+        package: 'pkg.custom_schema',
+        replayable: true,
+        change: {
+          type: 'add-class',
+          cls: { id: classId, name: 'AtomsState', doc: null, module: 'pkg.custom_schema', path: null, line: null, quantities: [], parentId: null, parentRelation: null },
+        },
+      },
+    ];
+    window.localStorage.setItem('schema-uml-audit', JSON.stringify(storedAudit));
+
+    mockGet.mockImplementation(commonGet(graphWithoutApplied));
+    mockPut.mockResolvedValue({ data: { workspace: { branch: 'develop', package: 'pkg.custom_schema', base_namespace: 'pkg' } } });
+
+    render(<App />);
+    const user = userEvent.setup();
+    await user.click(await screen.findByRole('button', { name: /\+ Start from empty canvas/i }));
+
+    await waitFor(() => expect(screen.queryAllByText(/0 active edits/i).length).toBeGreaterThan(0));
+    const archivedLocal = screen.getAllByText((_, node) => node?.textContent?.includes('Old local change') ?? false);
+    expect(archivedLocal[0]).toHaveTextContent(/archived/i);
+  });
+});


### PR DESCRIPTION
- Backend: include `applied_edits` in` /schema` responses so the UI knows which persisted custom classes/quantities were replayed 
- Frontend: parse `applied_edits`, seed them into the audit trail as archived entries, and auto-archive stale history on fresh graph loads so "active edits" reflects only current-session changes.
- Fixed UML class parent relation typing (ignoring `hasQuantity`) to restore successful builds