### PR TITLE
add governance & contributing

### DIFF
--- a/.github/releases.yml
+++ b/.github/releases.yml
@@ -1,0 +1,12 @@
+changelog:
+  exclude:
+    authors: [github-actions, pre-commit-ci]
+  categories:
+    - title: 💥 Incompatible API Changes
+      labels: [breaking, refactor]
+    - title: 💡 Added Functionalities (Backward Compatible)
+      labels: [feature, enhancement, DX, UX, docs, tests, security, performance]
+    - title: 🛠 Backward Compatible Bug Fixes And Minor Changes (Backward Compatible)
+      labels: [dependencies, fix, datamodel, pkg]
+    - title: 🤷‍♂️ Other Changes
+      labels: ['*']

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# Contributing
+
+## Where to contribute
+Please open issues and pull requests in the canonical upstream repository:
+https://github.com/EBB2675/schema-studio
+
+## Pull requests
+- Keep PRs focused and describe the change clearly.
+- Ensure tests/CI pass (if applicable).
+- Follow the project’s decision process in `GOVERNANCE.md`.
+
+## Licensing
+By submitting a pull request, you agree that your contribution is provided under the MIT License (see `LICENSE`).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,77 @@
+# Governance
+
+## Purpose
+Schema Studio is an open-source project developed collaboratively, providing a stable, community-oriented tool for exploring and editing data-model schemas. Its long-term goal is to enable interoperability by offering a shared platform for data models in materials science.
+
+## Guiding principles
+- Open science by default: permissive licensing and reproducible, reviewable changes
+- Shared maintainership with equal decision-making authority
+- Open development and transparent decisions
+- Stable releases and predictable change management
+
+## Repositories and project "upstream"
+
+### Canonical upstream
+The canonical upstream is the repository where:
+- issues are tracked
+- pull requests are opened and reviewed
+- releases are created and tagged
+- the roadmap is maintained
+
+This repository is the upstream unless explicitly changed by the maintainers.
+
+- Canonical upstream: [https://github.com/EBB2675/schema-studio]
+
+### Downstream mirrors
+Institutional or organizational repositories may host downstream mirrors for visibility, archival, or operational reasons (for example, CI, deployment, or sustainability requirements).
+
+Downstream mirrors are not considered the canonical development location unless the maintainers explicitly designate them as such.
+
+Downstream mirrors should:
+- clearly link back to the canonical upstream
+- normally disable issues and pull requests, or clearly redirect them to the canonical upstream
+- avoid accepting direct feature development unless explicitly coordinated with upstream
+- prefer tracking tagged releases or a protected `stable` branch
+
+If a downstream mirror accepts pull requests, changes should be limited to operational needs (for example packaging, deployment, documentation). The mirror should also keep in sync with upstream to avoid long-term divergence.
+
+## Roles
+
+### Maintainers
+Maintainers are responsible for:
+- reviewing and merging pull requests
+- triaging issues
+- managing releases
+- ensuring licensing and attribution remain correct
+- keeping governance documents up to date
+
+The current maintainers are listed in `MAINTAINERS.md`.
+
+New maintainers are added with approval from two existing maintainers.
+
+### Contributors
+Anyone can contribute via pull requests. Contributors are expected to follow the contribution process described in `CONTRIBUTING.md`.
+
+## Decision-making
+
+### Routine changes
+Bug fixes, refactors, documentation updates, and small improvements can be merged with approval from one maintainer.
+
+### Significant changes
+Any of the following require approval from two maintainers:
+- API or data model changes
+- architectural changes
+- new major dependencies
+- changes that affect licensing, copyright, or distribution
+- changes that impact backward compatibility
+
+## Releases
+- Releases are created from upstream and tagged using semantic versioning (for example, `v0.5.0`).
+- Release notes should summarize user-facing changes and any breaking changes.
+- Downstream mirrors may sync from tags or the protected `stable` branch.
+
+## Changes to governance
+This file can be changed only with approval from two maintainers.
+
+## Licensing
+Schema Studio is distributed under the MIT License (see `LICENSE`). Contributions are accepted under the same terms.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -23,7 +23,6 @@ This repository is the upstream unless explicitly changed by the maintainers.
 - Canonical upstream: [https://github.com/EBB2675/schema-studio]
 
 ### Downstream mirrors
-Institutional or organizational repositories may host downstream mirrors for visibility, archival, or operational reasons (for example, CI, deployment, or sustainability requirements).
 
 Downstream mirrors are not considered the canonical development location unless the maintainers explicitly designate them as such.
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,13 @@
+# Maintainers
+
+This file lists the current maintainers of Schema Studio.
+
+Maintainers are responsible for reviewing and merging pull requests, triaging issues, managing releases, and keeping governance documents up to date.
+
+## Current maintainers
+- Esma B. Boydaş (Humboldt-Universität zu Berlin / FAIRmat-NFDI) - @EBB2675
+- Jose M. Pizarro (Bundesanstalt fur Materialforschung und -prüfung (BAM)) - @JosePizarro3
+
+
+## Adding or removing maintainers
+Maintainers are added or removed with approval from two existing maintainers (see `GOVERNANCE.md`).

--- a/README.md
+++ b/README.md
@@ -171,15 +171,13 @@ Core endpoints:
 - `GET /schema/version`, `POST /schema/update`, `POST /send-design`
 - `GET /git/packages` (fixed branch behavior)
 
-## Author
+## Authors
 
 **[Dr. Esma B. Boydas](https://github.com/EBB2675)**  
-NOMAD Laboratory (FAIRmat), Humboldt-Universitat zu Berlin
-
-## Credits
+Humboldt-Universität zu Berlin / FAIRmat-NFDI
 
 **[Dr. Jose M. Pizarro](https://github.com/JosePizarro3)**  
-Bundesanstalt fur Materialforschung und -prufung (BAM)  
+Bundesanstalt fur Materialforschung und -prüfung (BAM)  
 Original idea and technical guidance.
 
 


### PR DESCRIPTION
- Adds `GOVERNANCE.md`: defines the canonical upstream repo, expectations for downstream mirrors, maintainer vs contributor roles, decision thresholds, release approach, and how governance itself can be changed.
- Adds a simple `CONTRIBUTING.md`: short contribution guide pointing people to open issues/PRs in the canonical upstream, basic PR expectations, and confirms contributions are under MIT.
- Adds `MAINTAINERS.md`
- Adds `.github/releases.yml`: a release-note / changelog categorization config mapping labels into sections (breaking, features, fixes, other).
- Edits `README.md`: minor wording/affiliation cleanup