### PR TITLE
feat: add tauri desktop shell scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ api/_data/
 .venv/
 .tmp/
 dist/
+web/src-tauri/target/
 schema_studio.egg*

--- a/README.md
+++ b/README.md
@@ -160,6 +160,30 @@ Open `https://localhost`.
   schema-studio
   ```
 
+## Desktop Development (Tauri Work-In-Progress)
+
+The desktop rollout is being developed incrementally on top of `tauri-changes-test`.
+
+Current direction:
+- Tauri manages a native window.
+- Tauri starts the Light Mode backend as a child process.
+- The backend must not open a browser when launched by Tauri.
+- Closing the desktop app should terminate the backend process tree.
+
+Current limitations observed in this environment:
+- `node` is not available on `PATH`
+- `cargo` is not available on `PATH`
+- `python -m venv .venv` hit an `ensurepip` permission issue here
+
+Planned dev smoke test once prerequisites are installed:
+```bash
+cd web
+npm install
+npm run tauri:dev
+```
+
+See `docs/tauri-light-mode-plan.md` for the branch-by-branch rollout and packaging strategy.
+
 ## API (Light Mode)
 
 Core endpoints:

--- a/api/light_mode/cli.py
+++ b/api/light_mode/cli.py
@@ -31,13 +31,29 @@ def _open_browser_when_ready(url: str, timeout_seconds: float = 120.0) -> None:
     webbrowser.open(url)
 
 
-def main() -> None:
+def _env_flag(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() not in {"0", "false", "no", "off"}
+
+
+def run_server(*, open_browser: bool | None = None) -> None:
     url = f"http://{DEFAULT_HOST}:{DEFAULT_PORT}"
     print(BANNER)
-    print(f"Launching browser at {url} when server is ready\n")
-    threading.Thread(target=_open_browser_when_ready, args=(url,), daemon=True).start()
+    if open_browser is None:
+        open_browser = _env_flag("SCHEMA_STUDIO_OPEN_BROWSER", True)
+    if open_browser:
+        print(f"Launching browser at {url} when server is ready\n")
+        threading.Thread(target=_open_browser_when_ready, args=(url,), daemon=True).start()
+    else:
+        print(f"Browser auto-open disabled; server available at {url}\n")
 
     uvicorn.run(app, host=DEFAULT_HOST, port=DEFAULT_PORT, log_level=os.getenv("UVICORN_LOG_LEVEL", "info"))
+
+
+def main() -> None:
+    run_server()
 
 
 if __name__ == "__main__":

--- a/web/package.json
+++ b/web/package.json
@@ -8,6 +8,9 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
+    "tauri": "tauri",
+    "tauri:dev": "tauri dev",
+    "tauri:build": "tauri build",
     "test": "vitest",
     "test:run": "vitest run",
     "test:contracts": "vitest run tests/contracts.test.ts"
@@ -28,6 +31,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.1",
     "@testing-library/user-event": "^14.6.1",
+    "@tauri-apps/cli": "^2.8.1",
     "@types/node": "^24.6.0",
     "@types/react": "^19.1.16",
     "@types/react-dom": "^19.1.9",

--- a/web/src-tauri/Cargo.toml
+++ b/web/src-tauri/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "schema-studio-desktop"
+version = "0.1.0"
+description = "Schema Studio desktop shell for Light Mode"
+authors = ["Schema Studio Team"]
+edition = "2021"
+
+[build-dependencies]
+tauri-build = { version = "2.2.0" }
+
+[dependencies]
+reqwest = { version = "0.12.24", default-features = false, features = ["blocking", "rustls-tls"] }
+tauri = { version = "2.8.1" }
+

--- a/web/src-tauri/build.rs
+++ b/web/src-tauri/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    tauri_build::build()
+}

--- a/web/src-tauri/src/main.rs
+++ b/web/src-tauri/src/main.rs
@@ -1,0 +1,133 @@
+use std::{
+    path::{Path, PathBuf},
+    process::{Child, Command, Stdio},
+    sync::{Arc, Mutex},
+    thread,
+    time::{Duration, Instant},
+};
+
+use tauri::{RunEvent, WebviewUrl, WebviewWindowBuilder};
+
+const APP_LABEL: &str = "main";
+const WINDOW_TITLE: &str = "Schema Studio Light";
+const BACKEND_HOST: &str = "127.0.0.1";
+const BACKEND_PORT: u16 = 5179;
+const BACKEND_URL: &str = "http://127.0.0.1:5179";
+const HEALTH_URL: &str = "http://127.0.0.1:5179/health";
+
+type SharedChild = Arc<Mutex<Option<Child>>>;
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("src-tauri should live under web/")
+        .to_path_buf()
+}
+
+fn preferred_python(repo_root: &Path) -> String {
+    let candidate = repo_root.join(".venv").join("Scripts").join("python.exe");
+    if candidate.exists() {
+        return candidate.to_string_lossy().into_owned();
+    }
+    "python".to_string()
+}
+
+fn spawn_backend() -> Result<Child, String> {
+    let repo_root = repo_root();
+    let mut cmd = Command::new(preferred_python(&repo_root));
+    cmd.current_dir(&repo_root)
+        .arg("-m")
+        .arg("api.light_mode.cli")
+        .env("SCHEMA_STUDIO_HOST", BACKEND_HOST)
+        .env("SCHEMA_STUDIO_PORT", BACKEND_PORT.to_string())
+        .env("SCHEMA_STUDIO_OPEN_BROWSER", "0")
+        .stdin(Stdio::null())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+
+    cmd.spawn()
+        .map_err(|err| format!("failed to launch Light Mode backend: {err}"))
+}
+
+fn wait_for_backend(timeout: Duration) -> Result<(), String> {
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(1))
+        .build()
+        .map_err(|err| format!("failed to build health-check client: {err}"))?;
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        match client.get(HEALTH_URL).send() {
+            Ok(response) if response.status().is_success() => return Ok(()),
+            _ => thread::sleep(Duration::from_millis(250)),
+        }
+    }
+    Err(format!(
+        "Light Mode backend did not become ready at {HEALTH_URL} within {} seconds",
+        timeout.as_secs()
+    ))
+}
+
+fn stop_backend(child_state: &SharedChild) {
+    let mut guard = child_state.lock().expect("backend child mutex poisoned");
+    if let Some(mut child) = guard.take() {
+        #[cfg(target_os = "windows")]
+        {
+            let _ = Command::new("taskkill")
+                .args(["/PID", &child.id().to_string(), "/T", "/F"])
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status();
+        }
+
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+}
+
+fn main() {
+    let backend_child: SharedChild = Arc::new(Mutex::new(None));
+    let managed_child = Arc::clone(&backend_child);
+
+    tauri::Builder::default()
+        .setup(move |app| {
+            let child = spawn_backend()?;
+            {
+                let mut guard = managed_child.lock().expect("backend child mutex poisoned");
+                *guard = Some(child);
+            }
+
+            if let Err(err) = wait_for_backend(Duration::from_secs(30)) {
+                stop_backend(&managed_child);
+                return Err(err.into());
+            }
+
+            WebviewWindowBuilder::new(
+                app,
+                APP_LABEL,
+                WebviewUrl::External(BACKEND_URL.parse().expect("valid backend URL")),
+            )
+            .title(WINDOW_TITLE)
+            .inner_size(1440.0, 960.0)
+            .min_inner_size(1100.0, 720.0)
+            .resizable(true)
+            .build()?;
+
+            Ok(())
+        })
+        .build(tauri::generate_context!())
+        .expect("error while building Schema Studio desktop shell")
+        .run(move |_app_handle, event| {
+            if matches!(event, RunEvent::Exit | RunEvent::ExitRequested { .. }) {
+                stop_backend(&backend_child);
+            }
+        });
+}

--- a/web/src-tauri/tauri.conf.json
+++ b/web/src-tauri/tauri.conf.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "productName": "Schema Studio Light",
+  "version": "0.1.0",
+  "identifier": "org.schemastudio.light",
+  "build": {
+    "beforeDevCommand": "",
+    "beforeBuildCommand": ""
+  },
+  "app": {
+    "windows": [
+      {
+        "label": "main",
+        "title": "Schema Studio Light",
+        "width": 1440,
+        "height": 960,
+        "minWidth": 1100,
+        "minHeight": 720,
+        "resizable": true,
+        "create": false
+      }
+    ],
+    "security": {
+      "csp": null
+    }
+  },
+  "bundle": {
+    "active": false,
+    "targets": "all"
+  }
+}


### PR DESCRIPTION
this is quite simplified: the scaffold of Tauri. this simply launches an empty, blank page when running the `npm run tauri:dev` command in the `web/` subfolder, no connection with schema-studio yet.

it touches the CLI as well, minimally, to define the BROWSER case for schema studio