### PR TITLE
refactor: formalize desktop mode launcher contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Useful desktop-specific variables:
 
 See `docs/tauri-light-mode-plan.md` for the branch-by-branch rollout and packaging strategy.
 See `docs/desktop-light-mode.md` for development, packaging, usage, and uninstall notes.
+See `docs/desktop-mode-extension.md` for how the desktop launcher is structured and how future modes can extend it.
 
 ## Windows Packaging (First Desktop Target)
 

--- a/docs/desktop-light-mode.md
+++ b/docs/desktop-light-mode.md
@@ -169,6 +169,6 @@ The desktop shell is now structured so shared launcher behavior is separate from
 
 See:
 
-- [desktop-mode-extension.md](/D:/REPOS/schema-studio/docs/desktop-mode-extension.md)
+- [desktop-mode-extension.md](./desktop-mode-extension.md)
 
 Use that guide before adding a heavier mode so startup, shutdown, and sidecar packaging stay consistent.

--- a/docs/desktop-light-mode.md
+++ b/docs/desktop-light-mode.md
@@ -153,6 +153,7 @@ npm run tauri:build:linux:portable
 - no extra browser tab opens
 - closing the app removes the backend listener on `127.0.0.1:5179`
 - `Build graph` succeeds for the default package
+- the launcher reports `light` behavior through the shared mode contract without changing the working Light Mode UX
 
 ### Packaged Windows build
 
@@ -161,3 +162,13 @@ npm run tauri:build:linux:portable
 - `Build graph` works immediately
 - local edits survive closing and reopening the app
 - uninstall works from Windows Settings
+
+## Extending Beyond Light Mode
+
+The desktop shell is now structured so shared launcher behavior is separate from mode-specific rules.
+
+See:
+
+- [desktop-mode-extension.md](/D:/REPOS/schema-studio/docs/desktop-mode-extension.md)
+
+Use that guide before adding a heavier mode so startup, shutdown, and sidecar packaging stay consistent.

--- a/docs/desktop-mode-extension.md
+++ b/docs/desktop-mode-extension.md
@@ -1,0 +1,80 @@
+# Desktop Mode Extension
+
+This document describes how the Tauri desktop launcher can be extended beyond Light Mode.
+
+## Current State
+
+The desktop shell now separates:
+
+- shared launcher behavior
+- mode-specific launch rules
+
+The shared behavior lives in:
+
+- [main.rs](/D:/REPOS/schema-studio/web/src-tauri/src/main.rs)
+
+The mode-specific behavior is represented by a small `ModeDescriptor` in that file.
+
+Today, only `light` is implemented. The `dev` mode name is reserved as a placeholder for future heavier modes.
+
+## What A Mode Defines
+
+Each desktop mode should define:
+
+- window title
+- sidecar basename
+- health endpoint path
+- Python launch command for development fallback
+
+That means a new mode can reuse the same:
+
+- environment loading
+- backend reuse checks
+- sidecar detection
+- health waiting
+- shutdown/process cleanup
+- Tauri window lifecycle
+
+## How To Add Another Mode
+
+1. Extend `DesktopMode` in [main.rs](/D:/REPOS/schema-studio/web/src-tauri/src/main.rs).
+2. Add a `ModeDescriptor::for_mode(...)` entry for the new mode.
+3. Define the new mode's:
+   - `window_title`
+   - `sidecar_basename`
+   - `health_path`
+   - `python_command()`
+4. Make sure the backend for that mode exposes the expected health endpoint.
+5. If the packaged build needs a different sidecar binary, ensure the build pipeline writes it under `web/src-tauri/binaries/` using the mode's basename.
+6. Add docs and packaging/test notes before exposing the mode to users.
+
+## Suggested Rules For Heavier Modes
+
+If a future mode needs more than one service:
+
+- keep the desktop shell responsible for top-level startup and shutdown
+- prefer one packaged entrypoint per mode rather than many loosely-managed child processes
+- make that entrypoint responsible for bringing up whatever local services the mode needs
+
+That keeps the Tauri shell simple and avoids turning the Rust launcher into a process orchestrator for every dependency.
+
+## Testing Checklist For A New Mode
+
+Before shipping a new mode, verify:
+
+- `npm run tauri:dev` launches the intended backend in that mode
+- the mode answers on its configured health endpoint
+- closing the app closes the backend tree
+- relaunching does not leave the previous backend bound to the old port
+- packaged builds prefer the sidecar over the Python fallback
+- installed builds still work when the source repo is absent
+
+## Current Recommendation
+
+Keep Light Mode as the production desktop target until another mode can satisfy the same bar:
+
+- installable
+- self-contained
+- reliable startup
+- reliable shutdown
+- testable without manual service wrangling

--- a/docs/desktop-mode-extension.md
+++ b/docs/desktop-mode-extension.md
@@ -11,7 +11,7 @@ The desktop shell now separates:
 
 The shared behavior lives in:
 
-- [main.rs](/D:/REPOS/schema-studio/web/src-tauri/src/main.rs)
+- [main.rs](../web/src-tauri/src/main.rs)
 
 The mode-specific behavior is represented by a small `ModeDescriptor` in that file.
 
@@ -37,7 +37,7 @@ That means a new mode can reuse the same:
 
 ## How To Add Another Mode
 
-1. Extend `DesktopMode` in [main.rs](/D:/REPOS/schema-studio/web/src-tauri/src/main.rs).
+1. Extend `DesktopMode` in [main.rs](../web/src-tauri/src/main.rs).
 2. Add a `ModeDescriptor::for_mode(...)` entry for the new mode.
 3. Define the new mode's:
    - `window_title`

--- a/docs/tauri-light-mode-plan.md
+++ b/docs/tauri-light-mode-plan.md
@@ -208,3 +208,15 @@ Important constraint:
 
 - Linux bundles should be produced on Linux, not on Windows
 - to maximize compatibility, build on an older supported base image or runner
+
+## Mode Extension Follow-Up
+
+After Windows and Linux Light Mode packaging, the next cleanup step is to keep the launcher extensible:
+
+- shared desktop shell behavior should stay generic
+- mode-specific details should live in a small launcher contract
+- future heavier modes should plug into that contract instead of duplicating process-management logic
+
+See:
+
+- [desktop-mode-extension.md](/D:/REPOS/schema-studio/docs/desktop-mode-extension.md)

--- a/docs/tauri-light-mode-plan.md
+++ b/docs/tauri-light-mode-plan.md
@@ -219,4 +219,4 @@ After Windows and Linux Light Mode packaging, the next cleanup step is to keep t
 
 See:
 
-- [desktop-mode-extension.md](/D:/REPOS/schema-studio/docs/desktop-mode-extension.md)
+- [desktop-mode-extension.md](./desktop-mode-extension.md)

--- a/web/src-tauri/src/main.rs
+++ b/web/src-tauri/src/main.rs
@@ -14,8 +14,6 @@ use std::{
 use tauri::{RunEvent, WebviewUrl, WebviewWindowBuilder};
 
 const APP_LABEL: &str = "main";
-const WINDOW_TITLE: &str = "Schema Studio Light";
-const SIDECAR_BASENAME: &str = "schema-studio-backend";
 
 type SharedChild = Arc<Mutex<Option<Child>>>;
 
@@ -37,9 +35,70 @@ impl DesktopMode {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
+struct ModeDescriptor {
+    mode: DesktopMode,
+    window_title: &'static str,
+    sidecar_basename: &'static str,
+    health_path: &'static str,
+}
+
+impl ModeDescriptor {
+    fn for_mode(mode: DesktopMode) -> Result<Self, String> {
+        match mode {
+            DesktopMode::Light => Ok(Self {
+                mode,
+                window_title: "Schema Studio Light",
+                sidecar_basename: "schema-studio-backend",
+                health_path: "/health",
+            }),
+            DesktopMode::Dev => Err(
+                "Desktop launcher mode extension is prepared, but only Light Mode is implemented right now."
+                    .to_string(),
+            ),
+        }
+    }
+
+    fn python_command(self) -> Vec<String> {
+        match self.mode {
+            DesktopMode::Light => vec!["-m".to_string(), "api.light_mode.cli".to_string()],
+            DesktopMode::Dev => Vec::new(),
+        }
+    }
+
+    fn sidecar_filename(self) -> String {
+        let triple = env::var("TAURI_ENV_TARGET_TRIPLE")
+            .or_else(|_| env::var("TARGET"))
+            .unwrap_or_else(|_| "x86_64-pc-windows-msvc".to_string());
+        if cfg!(target_os = "windows") {
+            return format!("{}-{triple}.exe", self.sidecar_basename);
+        }
+        format!("{}-{triple}", self.sidecar_basename)
+    }
+
+    fn packaged_backend_candidates(self, repo_root: &Path) -> Vec<PathBuf> {
+        let sidecar_name = self.sidecar_filename();
+        let mut candidates = vec![repo_root.join("web").join("src-tauri").join("binaries").join(&sidecar_name)];
+
+        if let Ok(current_exe) = env::current_exe() {
+            if let Some(exe_dir) = current_exe.parent() {
+                candidates.push(exe_dir.join(&sidecar_name));
+                candidates.push(exe_dir.join("resources").join(&sidecar_name));
+                candidates.push(exe_dir.join("Resources").join(&sidecar_name));
+            }
+        }
+
+        candidates
+    }
+
+    fn health_url(self, host: &str, port: u16) -> String {
+        format!("http://{host}:{port}{}", self.health_path)
+    }
+}
+
 #[derive(Clone, Debug)]
 struct LauncherConfig {
-    mode: DesktopMode,
+    mode: ModeDescriptor,
     host: String,
     port: u16,
     backend_override: Option<String>,
@@ -145,9 +204,10 @@ fn preferred_python(repo_root: &Path) -> String {
 
 impl LauncherConfig {
     fn from_env(repo_root: &Path) -> Result<Self, String> {
-        let mode = DesktopMode::parse(
+        let raw_mode = DesktopMode::parse(
             &env::var("SCHEMA_STUDIO_DESKTOP_MODE").unwrap_or_else(|_| "light".to_string()),
         )?;
+        let mode = ModeDescriptor::for_mode(raw_mode)?;
         let host =
             env::var("SCHEMA_STUDIO_DESKTOP_HOST").unwrap_or_else(|_| "127.0.0.1".to_string());
         let port = env_u16("SCHEMA_STUDIO_DESKTOP_PORT", 5179)?;
@@ -175,7 +235,7 @@ impl LauncherConfig {
     }
 
     fn health_url(&self) -> String {
-        format!("{}/health", self.base_url())
+        self.mode.health_url(&self.host, self.port)
     }
 
     fn socket_addr(&self) -> Result<SocketAddr, String> {
@@ -183,33 +243,6 @@ impl LauncherConfig {
             .parse()
             .map_err(|err| format!("Invalid desktop backend address {}:{}: {err}", self.host, self.port))
     }
-}
-
-fn sidecar_filename() -> String {
-    let triple = env::var("TAURI_ENV_TARGET_TRIPLE")
-        .or_else(|_| env::var("TARGET"))
-        .unwrap_or_else(|_| "x86_64-pc-windows-msvc".to_string());
-    if cfg!(target_os = "windows") {
-        return format!("{SIDECAR_BASENAME}-{triple}.exe");
-    }
-    format!("{SIDECAR_BASENAME}-{triple}")
-}
-
-fn packaged_backend_candidates(repo_root: &Path) -> Vec<PathBuf> {
-    let sidecar_name = sidecar_filename();
-    let mut candidates = vec![
-        repo_root.join("web").join("src-tauri").join("binaries").join(&sidecar_name),
-    ];
-
-    if let Ok(current_exe) = env::current_exe() {
-        if let Some(exe_dir) = current_exe.parent() {
-            candidates.push(exe_dir.join(&sidecar_name));
-            candidates.push(exe_dir.join("resources").join(&sidecar_name));
-            candidates.push(exe_dir.join("Resources").join(&sidecar_name));
-        }
-    }
-
-    candidates
 }
 
 enum BackendLaunch {
@@ -222,23 +255,13 @@ fn resolve_backend_launch(config: &LauncherConfig, repo_root: &Path) -> BackendL
         return BackendLaunch::Packaged(PathBuf::from(path));
     }
 
-    for candidate in packaged_backend_candidates(repo_root) {
+    for candidate in config.mode.packaged_backend_candidates(repo_root) {
         if candidate.exists() {
             return BackendLaunch::Packaged(candidate);
         }
     }
 
     BackendLaunch::PythonModule(config.python.clone())
-}
-
-fn mode_command(mode: DesktopMode) -> Result<Vec<String>, String> {
-    match mode {
-        DesktopMode::Light => Ok(vec!["-m".to_string(), "api.light_mode.cli".to_string()]),
-        DesktopMode::Dev => Err(
-            "Desktop launcher contract is ready for future modes, but only Light Mode is implemented right now."
-                .to_string(),
-        ),
-    }
 }
 
 fn spawn_backend(config: &LauncherConfig) -> Result<Child, String> {
@@ -256,7 +279,7 @@ fn spawn_backend(config: &LauncherConfig) -> Result<Child, String> {
         BackendLaunch::Packaged(path) => Command::new(path),
         BackendLaunch::PythonModule(python) => {
             let mut cmd = Command::new(python);
-            for arg in mode_command(config.mode)? {
+            for arg in config.mode.python_command() {
                 cmd.arg(arg);
             }
             cmd
@@ -415,7 +438,7 @@ fn create_window(app: &tauri::AppHandle, config: &LauncherConfig) -> Result<(), 
         APP_LABEL,
         WebviewUrl::External(config.base_url().parse().expect("valid backend URL")),
     )
-    .title(WINDOW_TITLE)
+    .title(config.mode.window_title)
     .inner_size(1440.0, 960.0)
     .min_inner_size(1100.0, 720.0)
     .resizable(true)


### PR DESCRIPTION
Refactor the Tauri launcher so mode-specific behavior is described through a small ModeDescriptor instead of being scattered across helper functions. This keeps Light Mode working while making future desktop modes easier to plug in without rewriting process lifecycle logic.

Also add extension-oriented documentation covering how to test the shared launcher contract and how to add another mode safely.